### PR TITLE
Webpack

### DIFF
--- a/config/initializers/webpack.rb
+++ b/config/initializers/webpack.rb
@@ -1,4 +1,5 @@
 if Rails.configuration.webpack[:use_manifest]
+
   asset_manifest  = Rails.root.join("config", "assets", "webpack-asset-manifest.json")
   common_manifest = Rails.root.join("config", "assets", "webpack-common-manifest.json")
 


### PR DESCRIPTION
Merges in changes that allow us to rollback a deploy by putting the webpack manifest in config rather than in the public folder. 

When merging DO NOT SQUASH MERGE. It will mess up pulling in changes from upstream.