### PR TITLE
Get proctor code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "cancancan"
 gem "devise"
 gem "ims-lti", "~> 1.1.13" # IMS LTI tool consumers and providers
 gem "jwt", "~> 1.5.0" # json web token
-gem "lms-api", "~> 1.2.7"
+gem "lms-api", "~> 1.2.8"
 gem "oauth", "~> 0.5.0"
 gem "omniauth"
 gem "omniauth-canvas", "~>1.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     kgio (2.11.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    lms-api (1.2.7)
+    lms-api (1.2.8)
       activesupport (>= 3.0)
       httparty
     loofah (2.0.3)
@@ -437,7 +437,7 @@ DEPENDENCIES
   ims-lti (~> 1.1.13)
   jwt (~> 1.5.0)
   launchy
-  lms-api (~> 1.2.7)
+  lms-api (~> 1.2.8)
   mail_view
   mailcatcher
   non-stupid-digest-assets

--- a/app/controllers/api/proctored_exams_controller.rb
+++ b/app/controllers/api/proctored_exams_controller.rb
@@ -15,7 +15,7 @@ class Api::ProctoredExamsController < ApplicationController
     render json: { error: "You do not have an exam that is ready to start." } unless @exam_request.present?
 
     account_params = {
-      account_id: @exam_request[:testing_center_id]
+      account_id: @exam_request[:testing_center_id],
     }
     users = canvas_api.proxy("LIST_USERS_IN_ACCOUNT", account_params)
 
@@ -25,7 +25,7 @@ class Api::ProctoredExamsController < ApplicationController
         custom_data_params = {
           ns: "edu.au.exam",
           scope: "/exam/proctor_code",
-          user_id: user["id"]
+          user_id: user["id"],
         }
         proctor_code = canvas_api.proxy("LOAD_CUSTOM_DATA", custom_data_params).parsed_response["data"]
         if proctor_code == params[:proctor_code]
@@ -36,7 +36,7 @@ class Api::ProctoredExamsController < ApplicationController
         # this probably means that the user doesnt have a proctor code... unfortunately canvas doesn't
         # actually tell us why it returned 401 just that it did
       end
-    end;
+    end
 
     if !matched_code
       render(

--- a/app/controllers/api/proctored_exams_controller.rb
+++ b/app/controllers/api/proctored_exams_controller.rb
@@ -1,23 +1,44 @@
 class Api::ProctoredExamsController < ApplicationController
   before_action :validate_proctor_code
+  include Concerns::CanvasSupport
 
   respond_to :json
 
   def start_proctored_exam
-    exam_request = ExamRequest.find_by(student_id: params[:student_id], status: "started")
-    if exam_request.present?
-      exam_request.update(status: "in progress")
-      render json: exam_request
-    else
-      render json: { error: "You do not have an exam that is ready to start." }
-    end
+    render json: @exam_request
   end
 
   private
 
   def validate_proctor_code
-    code = ProctorCode.find_by(code: params[:proctor_code])
-    if code.blank?
+    @exam_request = ExamRequest.find_by(student_id: params[:student_id], status: "started")
+    render json: { error: "You do not have an exam that is ready to start." } unless @exam_request.present?
+
+    account_params = {
+      account_id: @exam_request[:testing_center_id]
+    }
+    users = canvas_api.proxy("LIST_USERS_IN_ACCOUNT", account_params)
+
+    matched_code = false
+    users.parsed_response.each do |user|
+      begin
+        custom_data_params = {
+          ns: "edu.au.exam",
+          scope: "/exam/proctor_code",
+          user_id: user["id"]
+        }
+        proctor_code = canvas_api.proxy("LOAD_CUSTOM_DATA", custom_data_params).parsed_response["data"]
+        if proctor_code == params[:proctor_code]
+          @exam_request.update_attributes(unlocked_by_id: user["id"], unlocked_by_name: user["name"])
+          matched_code = true
+        end
+      rescue LMS::Canvas::InvalidAPIRequestFailedException
+        # this probably means that the user doesnt have a proctor code... unfortunately canvas doesn't
+        # actually tell us why it returned 401 just that it did
+      end
+    end;
+
+    if !matched_code
       render(
         json: { error: "Unauthorized: Invalid Proctor Code." },
         status: :unauthorized,

--- a/client/js/test_administration/components/exam_request_list/_exam_request_list.jsx
+++ b/client/js/test_administration/components/exam_request_list/_exam_request_list.jsx
@@ -11,8 +11,7 @@ import SearchBar               from './search_bar';
 import DateFilter              from './date_filter';
 import canvasRequest           from '../../../libs/canvas/action';
 import { createConversation }  from '../../../libs/canvas/constants/conversations';
-
- // import CenterError             from '../common/center_error';
+import { loadCustomData }      from '../../../libs/canvas/constants/users';
 import FilterTabs              from './filter_tabs';
 
 const select = state => ({
@@ -37,6 +36,7 @@ export class BaseExamRequestList extends React.Component {
     showModal: React.PropTypes.func.isRequired,
     canvasRequest: React.PropTypes.func.isRequired,
     startExam: React.PropTypes.func.isRequired,
+    lmsUserId: React.PropTypes.number
   };
 
   static tableHeader(styles) {
@@ -94,6 +94,11 @@ export class BaseExamRequestList extends React.Component {
   }
 
   componentWillMount() {
+    this.props.canvasRequest(loadCustomData, {
+      user_id: this.props.lmsUserId,
+      ns: 'edu.au.exam',
+      scope: '/exam/proctor_code'
+    });
     this.props.loadExamRequests(this.props.currentAccountId);
     this.props.testingCentersAccountSetup(
       this.props.currentAccountId,

--- a/client/js/test_administration/components/exam_request_list/_exam_request_list.jsx
+++ b/client/js/test_administration/components/exam_request_list/_exam_request_list.jsx
@@ -1,18 +1,19 @@
-import React                   from 'react';
-import { connect }             from 'react-redux';
-import _                       from 'lodash';
-import Fuse                    from 'fuse.js';
-import moment                  from 'moment';
-import * as ExamRequestActions from '../../actions/exam_requests';
-import * as ModalActions       from '../../../actions/modal';
-import Defines                 from '../../defines';
-import ExamRequest             from './exam_request';
-import SearchBar               from './search_bar';
-import DateFilter              from './date_filter';
-import canvasRequest           from '../../../libs/canvas/action';
-import { createConversation }  from '../../../libs/canvas/constants/conversations';
-import { loadCustomData }      from '../../../libs/canvas/constants/users';
-import FilterTabs              from './filter_tabs';
+import React                                    from 'react';
+import { connect }                              from 'react-redux';
+import _                                        from 'lodash';
+import Fuse                                     from 'fuse.js';
+import moment                                   from 'moment';
+import * as ExamRequestActions                  from '../../actions/exam_requests';
+import * as ModalActions                        from '../../../actions/modal';
+import Defines                                  from '../../defines';
+import ExamRequest                              from './exam_request';
+import SearchBar                                from './search_bar';
+import DateFilter                               from './date_filter';
+import canvasRequest                            from '../../../libs/canvas/action';
+import { createConversation }                   from '../../../libs/canvas/constants/conversations';
+import { loadCustomData, storeCustomData }      from '../../../libs/canvas/constants/users';
+import FilterTabs                               from './filter_tabs';
+import NewProctorCode                           from './new_proctor_code';
 
 const select = state => ({
   lmsUserId: state.settings.lms_user_id,
@@ -20,6 +21,7 @@ const select = state => ({
   toolConsumerInstanceName: state.settings.tool_consumer_instance_name,
   examRequestList: state.examRequests.examRequestList,
   centerIdError: state.examRequests.centerIdError,
+  needProctorCode: state.examRequests.needProctorCode
 });
 
 export class BaseExamRequestList extends React.Component {
@@ -36,7 +38,8 @@ export class BaseExamRequestList extends React.Component {
     showModal: React.PropTypes.func.isRequired,
     canvasRequest: React.PropTypes.func.isRequired,
     startExam: React.PropTypes.func.isRequired,
-    lmsUserId: React.PropTypes.number
+    lmsUserId: React.PropTypes.number,
+    needProctorCode: React.PropTypes.bool.isRequired,
   };
 
   static tableHeader(styles) {
@@ -104,6 +107,24 @@ export class BaseExamRequestList extends React.Component {
       this.props.currentAccountId,
       this.props.toolConsumerInstanceName
     );
+  }
+
+  componentWillUpdate(nextProps) {
+    if (!this.props.needProctorCode && nextProps.needProctorCode) {
+      // a random code between 7 and 8 digits, this will go a way once u4 finishes their stuff.
+      // it will look something like b9f25fc4
+      const code = Math.random().toString(16).substring(7);
+      this.props.canvasRequest(storeCustomData, {
+        user_id: this.props.lmsUserId,
+      }, {
+        ns: 'edu.au.exam',
+        scope: '/exam/proctor_code',
+        data: code
+      });
+      this.props.showModal(
+        <NewProctorCode code={code} hideModal={this.props.hideModal} />
+      );
+    }
   }
 
   getExamRequestRows() {

--- a/client/js/test_administration/components/exam_request_list/_exam_request_list.spec.jsx
+++ b/client/js/test_administration/components/exam_request_list/_exam_request_list.spec.jsx
@@ -16,7 +16,8 @@ describe('Exam Assignment list', () => {
       }, {
         student_name: 'James',
         status: 'scheduled'
-      }]
+      }],
+      canvasRequest: () => {}
     };
     result = TestUtils.renderIntoDocument(<BaseExamRequestList {...props} />);
   });

--- a/client/js/test_administration/components/exam_request_list/new_proctor_code.jsx
+++ b/client/js/test_administration/components/exam_request_list/new_proctor_code.jsx
@@ -1,0 +1,69 @@
+import React        from 'react';
+import Defines      from '../../defines';
+import HoverButton  from '../common/hover_button';
+
+export default class NewProctorCode extends React.Component {
+  static propTypes = {
+    hideModal: React.PropTypes.func.isRequired,
+    code: React.PropTypes.string.isRequired,
+  };
+
+  static getStyles() {
+    return {
+      popupStyle: {
+        boxShadow: `0px 0px 5px ${Defines.darkGrey}`,
+        backgroundColor: 'white',
+        padding: '20px',
+        position: 'fixed',
+        top: '10vh',
+        bottom: '50vh',
+        left: '10vw',
+        right: '10vw',
+        borderRadius: '5px',
+        zIndex: '2',
+      },
+      exitButtonStyle: {
+        border: 'none',
+        cursor: 'pointer',
+        backgroundColor: 'white',
+        color: Defines.lightText,
+        position: 'absolute',
+        top: '20px',
+        right: '20px',
+        padding: '0px',
+      },
+      message: {
+        textAlign: 'center',
+        color: Defines.darkGrey,
+      },
+      code: {
+        fontSize: '3em',
+        border: `1px solid ${Defines.lightText}`,
+        borderRadius: '2px'
+      }
+    };
+  }
+
+
+  render() {
+    const styles = NewProctorCode.getStyles();
+    return (
+      <div style={styles.popupStyle}>
+        New proctor code
+        <HoverButton
+          className="spec_clear_button"
+          style={styles.exitButtonStyle}
+          onClick={this.props.hideModal}
+        >
+          <i className="material-icons">clear</i>
+        </HoverButton>
+        <div style={{ clear: 'both' }} />
+        <div style={styles.message}>
+          <h1>Your proctor code is: </h1>
+          <h2 style={styles.code}>{this.props.code}</h2>
+          <div>Please write this down as you will not be able to retrieve it again</div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/client/js/test_administration/components/exam_request_list/new_proctor_code.spec.jsx
+++ b/client/js/test_administration/components/exam_request_list/new_proctor_code.spec.jsx
@@ -1,0 +1,15 @@
+import React            from 'react';
+import TestUtils        from 'react-addons-test-utils';
+import NewProctorCode   from './new_proctor_code';
+
+describe('new proctor code', () => {
+  it('renders the proctor code', () => {
+    const props = {
+      code: 'america',
+      hideModal: () => {}
+    };
+    const result = TestUtils.renderIntoDocument(<NewProctorCode {...props} />);
+    const element = TestUtils.scryRenderedDOMComponentsWithTag(result, 'div')[0];
+    expect(element.textContent).toContain('america');
+  });
+});

--- a/client/js/test_administration/reducers/exam_requests.js
+++ b/client/js/test_administration/reducers/exam_requests.js
@@ -5,6 +5,7 @@ const defaultState = {
   centerIdError: false,
   quizzes: {},
   signedUrl: null,
+  needProctorCode: false,
 };
 
 export default function examRequests(state = defaultState, action) {
@@ -43,6 +44,15 @@ export default function examRequests(state = defaultState, action) {
 
     case 'GET_SIGNED_URL_DONE': {
       return { ...state, signedUrl: action.payload.signed_url };
+    }
+
+    case 'LOAD_CUSTOM_DATA_DONE': {
+      // this is bad because it assumes that a server error means
+      // that canvas didnt have the data we are looking for but there is not another way to do it.
+      if (action.error) {
+        return { ...state, needProctorCode: true };
+      }
+      return state;
     }
 
     default:

--- a/db/migrate/20170301203616_add_unlocked_by_id_and_name_to_exam_request.rb
+++ b/db/migrate/20170301203616_add_unlocked_by_id_and_name_to_exam_request.rb
@@ -1,0 +1,6 @@
+class AddUnlockedByIdAndNameToExamRequest < ActiveRecord::Migration
+  def change
+    add_column :exam_requests, :unlocked_by_id, :integer
+    add_column :exam_requests, :unlocked_by_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170222192423) do
+ActiveRecord::Schema.define(version: 20170301203616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,6 +104,8 @@ ActiveRecord::Schema.define(version: 20170222192423) do
     t.string   "message"
     t.date     "scheduled_date"
     t.string   "scheduled_time"
+    t.integer  "unlocked_by_id"
+    t.string   "unlocked_by_name"
   end
 
   create_table "nonces", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,7 +94,15 @@ applications = [
     name: "Test Administration Tool",
     description: "Test Administration",
     client_application_name: "test_administration",
-    canvas_api_permissions: "GET_SINGLE_QUIZ,LIST_QUESTIONS_IN_QUIZ_OR_SUBMISSION,CREATE_CONVERSATION",
+    canvas_api_permissions: %w{
+      GET_SINGLE_QUIZ
+      LIST_QUESTIONS_IN_QUIZ_OR_SUBMISSION
+      CREATE_CONVERSATION
+      LIST_USERS_IN_ACCOUNT
+      STORE_CUSTOM_DATA
+      LOAD_CUSTOM_DATA
+      DELETE_CUSTOM_DATA
+    }.join(","),
     kind: Application.kinds[:lti],
     application_instances: [{
       tenant: "exam",


### PR DESCRIPTION
this does a few things:
- makes it so that if a proctor opens the app and doesnt have a proctor code it creates one for them
- when a proctor goes to unlock an exam it checks canvas for the proctor codes so we dont have to sync all the data to adhesion