### PR TITLE
Fix shared_auth to use correct field of tenant.

### DIFF
--- a/lib/tasks/shared_auth.rake
+++ b/lib/tasks/shared_auth.rake
@@ -2,7 +2,7 @@ desc "generates a shared authorization token"
 task shared_auth: [:environment] do
   secret = ::SecureRandom::hex(64)
   ApplicationInstance.all.each do |instance|
-    Apartment::Tenant.switch(instance.lti_key)
+    Apartment::Tenant.switch(instance.tenant)
     SharedAuth.create(secret: secret)
   end
   puts secret


### PR DESCRIPTION
We no longer use lti_key for the tenant key.