### PR TITLE
Fixing  zooming on attendance

### DIFF
--- a/client/styles/attendance/partials/_index.scss
+++ b/client/styles/attendance/partials/_index.scss
@@ -1,7 +1,8 @@
 .c-top-bar{
   height: 6rem;
   padding: 1rem;
-  max-width: 75rem;
+  min-width: 70rem;
+  width: 100%;
   position: relative;
 }
 
@@ -115,7 +116,8 @@
 .c-table{
   margin-top: 1rem;
   width: 100%;
-  max-width: 75rem;
+  max-width: 175rem;
+  min-width: 70rem;
   border-collapse: collapse;
 
   tr{


### PR DESCRIPTION
Before this, zooming(cmd +) would move the components but now they will stay in place. 