### PR TITLE
Fixed ui export dialog boxes being cut off

### DIFF
--- a/client/styles/attendance/partials/_index.scss
+++ b/client/styles/attendance/partials/_index.scss
@@ -350,6 +350,5 @@
     font-size: 14px;
     border-color: transparent;
     line-height: 22px;
-    padding: 6px 10px 5px;
   }
 }


### PR DESCRIPTION
I've tested this on Chrome, Firefox, and Safari