### PR TITLE
Prevents blank 303, and correctly adds file to canvas

### DIFF
--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -129,26 +129,25 @@ class Api::ScormCoursesController < ApplicationController
         },
       ).parsed_response
       canvas_response["upload_params"]["file"] = File.new(file.tempfile)
-      RestClient.post(
+      response = RestClient.post(
         canvas_response["upload_url"],
         canvas_response["upload_params"],
-      ) do |response|
-        case response.code
-        when 200
-          JSON.parse(response.body)["id"]
-        when 302
-          # When redirected, the body has a link to the file similar to:
-          # canvas.com/api/v1/files/573347/create_success
-          body = response.body
-          scanner = StringScanner.new body
-          scanner.scan_until(/api\/.+\/files\//)
-          # scanner will now be at
-          # 573347/create_success
-          id = scanner.scan_until(/\//)
-          # id will be 573347/
-          # now remove the / and return 573347
-          id[0...-1]
-        end
+      )
+      case response.code
+      when 200
+        JSON.parse(response.body)["id"]
+      when 302
+        # When redirected, the body has a link to the file similar to:
+        # canvas.com/api/v1/files/573347/create_success
+        body = response.body
+        scanner = StringScanner.new body
+        scanner.scan_until(/api\/.+\/files\//)
+        # scanner will now be at
+        # 573347/create_success
+        id = scanner.scan_until(/\//)
+        # id will be 573347/
+        # now remove the / and return 573347
+        id[0...-1]
       end
     end
   end


### PR DESCRIPTION
The do block was returning a blank 303 and not posting the file to canvas. This small change added the file correctly and returned the appropriate response.