### PR TITLE
Wait for scorm engine to finish processing.

### DIFF
--- a/app/services/scorm_engine_service.rb
+++ b/app/services/scorm_engine_service.rb
@@ -69,13 +69,39 @@ class ScormEngineService
           file: UploadIO.new(zip, "zip/zip", file.original_filename),
         },
       ) do |response|
+        import_job_id = JSON.parse(response.body)["result"]
+        import_status = check_import_progress(import_job_id)
         course = {}
         course[:response] = {}
         course[:response][:title] = get_scorm_title(course_id)
-        course[:status] = response.code
+        course[:status] = if import_status == "COMPLETE"
+                            200
+                          else
+                            500
+                          end
         course
       end
     end
+  end
+
+  ##
+  # Loop to check the import progress
+  # Stop looping when the job finishes
+  # Or when the backoff is greater than 36
+  # Which is equivalent to 234 seconds or nearly 4 minutes
+  ##
+  def check_import_progress(import_job_id)
+    url = "#{@scorm_tenant_url}/courses/importJobs/#{import_job_id}"
+    status = "RUNNING"
+    backoff = 0
+    loop do
+      response = send_get_request(url)
+      status = JSON.parse(response.body)["status"]
+      break if ["COMPLETE", "ERROR"].include? status || backoff > 36
+      backoff += 3
+      sleep backoff
+    end
+    status
   end
 
   def get_scorm_title(course_id)


### PR DESCRIPTION
Wait before getting title to the course to move on.
Use a backoff rather than always asking in a specific interval.