### PR TITLE
Add syslog/logger to application config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,8 @@
-require_relative 'boot'
+require_relative "boot"
 require_relative "../app/lib/middleware/oauth_state_middleware"
 
-require 'rails/all'
+require "rails/all"
+require "syslog/logger"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
This used to be included with rails/all but no longer is