### PR TITLE
Use Admin for Auth

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -22,7 +22,7 @@ class Application < ActiveRecord::Base
   PUBLIC_TENANT = "public".freeze
 
   ADMIN = "admin".freeze
-  AUTH = "auth".freeze
+  AUTH = "admin".freeze
 
   SCORM = "scorm".freeze
   ATTENDANCE = "attendance".freeze


### PR DESCRIPTION
Using the 'admin' subdomain for authenticating via OAuth with Canvas.