### PR TITLE
Improve attendance creation/update

### DIFF
--- a/app/controllers/api/attendances_controller.rb
+++ b/app/controllers/api/attendances_controller.rb
@@ -4,17 +4,6 @@ class Api::AttendancesController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :validate_token
 
-  def attendance_params(student, params)
-    {
-      name: student[:name],
-      sortable_name: student[:sortable_name],
-      lms_student_id: student[:lms_student_id],
-      lms_course_id: params[:lms_course_id],
-      date: params[:date],
-      status: params[:status],
-    }
-  end
-
   def students
     filtered_params = params.permit(
       students: [:name, :lms_student_id, :sortable_name],
@@ -25,22 +14,29 @@ class Api::AttendancesController < ApplicationController
   def create
     attendances = []
     Attendance.transaction do
-      students.each do |student|
-        att_params = attendance_params(student, params)
+      existing_attendances = Attendance.where(
+        lms_course_id: params[:lms_course_id],
+        date: params[:date],
+        lms_student_id: students.pluck(:lms_student_id),
+      )
 
-        attendance = Attendance.where(
-          lms_student_id: att_params[:lms_student_id],
-          lms_course_id: att_params[:lms_course_id],
-          date: att_params[:date],
-        ).first_or_create
-
-        # status = PRESENT, LATE, ABSENT
-        if att_params[:status].blank?
-          attendance.destroy
+      # status = PRESENT, LATE, ABSENT, ""
+      if params[:status].blank?
+        existing_attendances.destroy_all
+      else
+        existing_attendances.update_all(status: params[:status])
+        if existing_attendances.count < students.length
+          student_ids = students.pluck(:lms_student_id) - existing_attendances.pluck(:lms_student_id)
+          students_to_create = students.select { |student| student_ids.include?(student[:lms_student_id]) }
+          existing_and_new_attendances = Attendance.where(
+            lms_course_id: params[:lms_course_id],
+            date: params[:date],
+            status: params[:status],
+          ).create(students_to_create)
+          attendances = existing_and_new_attendances
         else
-          attendance.update(att_params)
+          attendances = existing_attendances
         end
-        attendances << attendance unless attendance.destroyed?
       end
     end
     render json: attendances
@@ -48,8 +44,8 @@ class Api::AttendancesController < ApplicationController
 
   def search
     @attendances = Attendance.where(
-      date: params[:date],
       lms_course_id: params[:course_id],
+      date: params[:date],
     )
     render json: @attendances
   end

--- a/spec/controllers/api/attendances_controller_spec.rb
+++ b/spec/controllers/api/attendances_controller_spec.rb
@@ -6,28 +6,22 @@ RSpec.describe Api::AttendancesController, type: :controller do
     @user.confirm
     @user_token = AuthToken.issue_token(user_id: @user.id)
     request.headers["Authorization"] = @user_token
-    @course = ScormCourse.create
   end
 
   describe "POST #create" do
     before do
-      student1 = create(:user)
-      student2 = create(:user)
-      students = [
-        {
-          name: student1.name,
-          sortable_name: student1.name,
-          lms_student_id: student1.id,
-        },
-        {
-          name: student2.name,
-          sortable_name: student2.name,
-          lms_student_id: student2.id,
-        },
-      ]
+      students = []
+      2.times do
+        name = generate(:name)
+        students << {
+          name: name,
+          sortable_name: name,
+          lms_student_id: generate(:student_id),
+        }
+      end
       @params = {
-        course_id: @course.id,
-        lms_course_id: 123,
+        course_id: generate(:course_id),
+        lms_course_id: generate(:course_id),
         date: Date.today,
         status: "PRESENT",
         students: students,
@@ -35,24 +29,24 @@ RSpec.describe Api::AttendancesController, type: :controller do
     end
 
     it "successfully creates an attendance" do
-      expect { post :create, @params }.to change { Attendance.count }.by(2)
+      expect { post :create, params: @params }.to change { Attendance.count }.by(2)
     end
 
     it "returns index json" do
-      post :create, @params
+      post :create, params: @params
       expect(response.content_type).to eq("application/json")
     end
 
     it "successfully updates existing attendance record" do
       params_clone = @params.clone
-      post :create, params_clone
+      post :create, params: params_clone
       attendances = JSON.parse(response.body)
       expect(attendances.count).to eq(2)
       expect(attendances.first["status"]).to eq("PRESENT")
       expect(attendances.second["status"]).to eq("PRESENT")
 
       params_clone[:status] = "ABSENT"
-      post :create, params_clone
+      post :create, params: params_clone
       expect(response).to be_success
       attendances = JSON.parse(response.body)
       expect(attendances.count).to eq(2)
@@ -62,7 +56,7 @@ RSpec.describe Api::AttendancesController, type: :controller do
 
     it "successfully deletes existing attendance record" do
       params_clone = @params.clone
-      post :create, params_clone
+      post :create, params: params_clone
 
       params_clone[:status] = ""
       students = [
@@ -73,7 +67,7 @@ RSpec.describe Api::AttendancesController, type: :controller do
         },
       ]
       params_clone[:students] = students
-      expect { post :create, params_clone }.to change { Attendance.count }.by(-1)
+      expect { post :create, params: params_clone }.to change { Attendance.count }.by(-1)
     end
   end
 
@@ -81,7 +75,7 @@ RSpec.describe Api::AttendancesController, type: :controller do
     it "successfully returns the correct attendance record" do
       attendance1 = create(:attendance)
       create(:attendance, date: Date.today - 2.days)
-      get :search, course_id: attendance1[:lms_course_id], date: attendance1.date
+      get :search, params: { course_id: attendance1[:lms_course_id], date: attendance1.date }
       result = JSON.parse(response.body)
       expect(result.count).to eq(1)
       expect(result.first["id"]).to eq(attendance1.id)
@@ -89,7 +83,7 @@ RSpec.describe Api::AttendancesController, type: :controller do
 
     it "renders json" do
       attendance = create(:attendance)
-      get :search, course_id: attendance[:lms_course_id], date: attendance.date
+      get :search, params: { course_id: attendance[:lms_course_id], date: attendance.date }
       expect(response.content_type).to eq("application/json")
     end
   end


### PR DESCRIPTION
Refactor so not as many database hits happen

# Course with 250 students marking all present #

before refactoring api:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/1216167/31733294-7627f4dc-b3f8-11e7-994d-46e2e50ebc93.png">


after refactoring api:
<img width="467" alt="image" src="https://user-images.githubusercontent.com/1216167/31738392-babf110c-b407-11e7-8a0f-c5da77efeb2e.png">

