### PR TITLE
Adds monkey patch to ruby core that fixes dns resolution for proxy

### DIFF
--- a/config/initializers/core_patches.rb
+++ b/config/initializers/core_patches.rb
@@ -1,0 +1,1 @@
+URI::Generic.prepend CoreExtensions::Uri::Generic

--- a/config/initializers/core_patches.rb
+++ b/config/initializers/core_patches.rb
@@ -1,1 +1,4 @@
+# Monkey patch the Uri Generic class find_proxy method
+# We are removing code that attempts to resolve a host name
+# without using the proxy so that the request doesn't time out.
 URI::Generic.prepend CoreExtensions::Uri::Generic

--- a/lib/core_extensions/uri/generic.rb
+++ b/lib/core_extensions/uri/generic.rb
@@ -1,0 +1,102 @@
+#################################################################
+# Monkey patch the Uri Generic class find_proxy method
+# We are removing code that attempts to resolve a host name
+# without using the proxy
+# Add the following to an initializer to monkey patch:
+# URI::Generic.include CoreExtensions::Uri::Generic
+#################################################################
+module CoreExtensions
+  module Uri
+    module Generic
+
+      # returns a proxy URI.
+      # The proxy URI is obtained from environment variables such as http_proxy,
+      # ftp_proxy, no_proxy, etc.
+      # If there is no proper proxy, nil is returned.
+      #
+      # If the optional parameter, +env+, is specified, it is used instead of ENV.
+      #
+      # Note that capitalized variables (HTTP_PROXY, FTP_PROXY, NO_PROXY, etc.)
+      # are examined too.
+      #
+      # But http_proxy and HTTP_PROXY is treated specially under CGI environment.
+      # It's because HTTP_PROXY may be set by Proxy: header.
+      # So HTTP_PROXY is not used.
+      # http_proxy is not used too if the variable is case insensitive.
+      # CGI_HTTP_PROXY can be used instead.
+      def find_proxy(env=ENV)
+        raise BadURIError, "relative URI: #{self}" if self.relative?
+        name = self.scheme.downcase + '_proxy'
+        proxy_uri = nil
+        if name == 'http_proxy' && env.include?('REQUEST_METHOD') # CGI?
+          # HTTP_PROXY conflicts with *_proxy for proxy settings and
+          # HTTP_* for header information in CGI.
+          # So it should be careful to use it.
+          pairs = env.reject {|k, v| /\Ahttp_proxy\z/i !~ k }
+          case pairs.length
+          when 0 # no proxy setting anyway.
+            proxy_uri = nil
+          when 1
+            k, _ = pairs.shift
+            if k == 'http_proxy' && env[k.upcase] == nil
+              # http_proxy is safe to use because ENV is case sensitive.
+              proxy_uri = env[name]
+            else
+              proxy_uri = nil
+            end
+          else # http_proxy is safe to use because ENV is case sensitive.
+            proxy_uri = env.to_hash[name]
+          end
+          if !proxy_uri
+            # Use CGI_HTTP_PROXY.  cf. libwww-perl.
+            proxy_uri = env["CGI_#{name.upcase}"]
+          end
+        elsif name == 'http_proxy'
+          unless proxy_uri = env[name]
+            if proxy_uri = env[name.upcase]
+              warn 'The environment variable HTTP_PROXY is discouraged.  Use http_proxy.'
+            end
+          end
+        else
+          proxy_uri = env[name] || env[name.upcase]
+        end
+
+        if proxy_uri.nil? || proxy_uri.empty?
+          return nil
+        end
+
+        # CHANGE Removed this code as it attempt to resolve the hostname
+        # without using the proxy which causes problems in deployments
+        # where the proxy is the only/best way to resolve the name
+        # if self.hostname
+        #   require 'socket'
+        #   begin
+        #     addr = IPSocket.getaddress(self.hostname)
+        #     return nil if /\A127\.|\A::1\z/ =~ addr
+        #   rescue SocketError
+        #   end
+        # end
+
+        name = 'no_proxy'
+        if no_proxy = env[name] || env[name.upcase]
+          no_proxy.scan(/(?!\.)([^:,\s]+)(?::(\d+))?/) {|host, port|
+            if (!port || self.port == port.to_i)
+              if /(\A|\.)#{Regexp.quote host}\z/i =~ self.host
+                return nil
+              elsif addr
+                require 'ipaddr'
+                return nil if
+                  begin
+                    IPAddr.new(host)
+                  rescue IPAddr::InvalidAddressError
+                    next
+                  end.include?(addr)
+              end
+            end
+          }
+        end
+        URI.parse(proxy_uri)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby's Net::HTTP library calls IPSocket.getaddress(self.hostname) to resolve a host when using a proxy. We depend on the proxy to resolve the DNS and so the request must wait for the call to timeout and die. This causes our API calls to timeout. This PR monkey patches the core ruby code to remove the call so that we only use the proxy for our request.