### PR TITLE
Use apartment-activejob-que to assist with background jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "rails", "5.0.2"
 
 # Database
 gem "apartment"
-gem "apartment-activejob", git: "https://github.com/bfcoder/apartment-activejob", branch: "bf-enqueue-public-tenant"
 gem "pg"
 
 # authentication, authorization, integrations
@@ -40,6 +39,7 @@ gem "yajl-ruby", require: "yajl"
 gem "puma"
 
 # job worker
+gem "apartment-activejob-que"
 gem "que", "~> 0.14.0"
 
 # API Related

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "rails", "5.0.2"
 
 # Database
 gem "apartment"
+gem "apartment-activejob", git: "https://github.com/bfcoder/apartment-activejob", branch: "bf-enqueue-public-tenant"
 gem "pg"
 
 # authentication, authorization, integrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,15 @@ GIT
       uuid
 
 GIT
+  remote: https://github.com/bfcoder/apartment-activejob
+  revision: d6f212bf1e34ab65cebcfd978d67b11439dee47f
+  branch: bf-enqueue-public-tenant
+  specs:
+    apartment-activejob (0.0.1)
+      activesupport
+      apartment
+
+GIT
   remote: https://github.com/instructure/scorm-cloud.git
   revision: 8288c51a6b3fcf2d12ff6f1b171c77724c0fe84e
   specs:
@@ -433,6 +442,7 @@ PLATFORMS
 DEPENDENCIES
   aj-ims-lti!
   apartment
+  apartment-activejob!
   attr_encrypted
   autoprefixer-rails
   better_errors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,6 @@ GIT
       uuid
 
 GIT
-  remote: https://github.com/bfcoder/apartment-activejob
-  revision: d6f212bf1e34ab65cebcfd978d67b11439dee47f
-  branch: bf-enqueue-public-tenant
-  specs:
-    apartment-activejob (0.0.1)
-      activesupport
-      apartment
-
-GIT
   remote: https://github.com/instructure/scorm-cloud.git
   revision: 8288c51a6b3fcf2d12ff6f1b171c77724c0fe84e
   specs:
@@ -71,6 +62,9 @@ GEM
       activerecord (>= 3.1.2, < 6.0)
       public_suffix (~> 2.0.5)
       rack (>= 1.3.6)
+    apartment-activejob-que (0.0.2)
+      activesupport
+      apartment
     arel (7.1.4)
     ast (2.3.0)
     attr_encrypted (3.0.3)
@@ -442,7 +436,7 @@ PLATFORMS
 DEPENDENCIES
   aj-ims-lti!
   apartment
-  apartment-activejob!
+  apartment-activejob-que
   attr_encrypted
   autoprefixer-rails
   better_errors

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -12,18 +12,14 @@ class ExportsController < ApplicationController
       params[:end_date],
     )
     if attendances.count > 1000
-      tenant = Apartment::Tenant.current
-      Apartment::Tenant.switch(Application::PUBLIC_TENANT) do
-        AttendanceReportJob.
-          perform_later(
-            tenant,
-            current_application_instance.id,
-            current_user.id,
-            params[:course_id],
-            params[:start_date],
-            params[:end_date],
-          )
-      end
+      AttendanceReportJob.
+        perform_later(
+          current_application_instance.id,
+          current_user.id,
+          params[:course_id],
+          params[:start_date],
+          params[:end_date],
+        )
       render json: { large_file: true }
     else
       final_csv = AttendanceExportsHelper.generate_csv(attendances)

--- a/app/jobs/attendance_report_job.rb
+++ b/app/jobs/attendance_report_job.rb
@@ -4,28 +4,25 @@ class AttendanceReportJob < ApplicationJob
   queue_as :default
 
   def perform(
-    tenant,
     application_instance_id,
     user_id,
     lms_course_id,
     start_date,
     end_date
   )
-    Apartment::Tenant.switch(tenant) do
-      application_instance = ApplicationInstance.find(application_instance_id)
-      current_user = User.find(user_id)
-      current_course = Course.find_by(lms_course_id: lms_course_id)
-      @canvas_api = canvas_api(
-        application_instance: application_instance,
-        user: current_user,
-        course: current_course,
-      )
-      attendances = AttendanceExportsHelper.get_attendances(lms_course_id, start_date, end_date)
-      final_csv = AttendanceExportsHelper.generate_csv(attendances)
-      new_file = write_file(final_csv)
-      upload_canvas_file(new_file, lms_course_id)
-      FileUtils.remove_entry_secure(new_file)
-    end
+    application_instance = ApplicationInstance.find(application_instance_id)
+    current_user = User.find(user_id)
+    current_course = Course.find_by(lms_course_id: lms_course_id)
+    @canvas_api = canvas_api(
+      application_instance: application_instance,
+      user: current_user,
+      course: current_course,
+    )
+    attendances = AttendanceExportsHelper.get_attendances(lms_course_id, start_date, end_date)
+    final_csv = AttendanceExportsHelper.generate_csv(attendances)
+    new_file = write_file(final_csv)
+    upload_canvas_file(new_file, lms_course_id)
+    FileUtils.remove_entry_secure(new_file)
   end
 
   def write_file(data)

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,3 @@
+class ActiveJob::Base
+  include Apartment::ActiveJob
+end

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,3 +1,5 @@
+require "apartment/active_job"
+
 class ActiveJob::Base
   include Apartment::ActiveJob
 end

--- a/spec/jobs/attendance_report_job_spec.rb
+++ b/spec/jobs/attendance_report_job_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe AttendanceReportJob, type: :job do
   subject { AttendanceReportJob }
 
-  let(:tenant) { Application::PUBLIC_TENANT }
   let(:application_instance_id) { create(:application_instance).id }
   let(:user_id) { create(:user).id }
   let(:lms_course_id) { create(:course).lms_course_id }
@@ -15,7 +14,6 @@ RSpec.describe AttendanceReportJob, type: :job do
       with(kind_of(File), lms_course_id)
 
     subject.perform_now(
-      tenant,
       application_instance_id,
       user_id,
       lms_course_id,


### PR DESCRIPTION
This allows us to enqueue jobs without manually enqueueing them on the public tenant, the gem does it for us.