### PR TITLE
Improve SCORM uploads

### DIFF
--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -113,6 +113,7 @@ class Api::ScormCoursesController < ApplicationController
   def copy_to_storage(file)
     storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.mktmpdir
     duplicate_file_path = File.join(storage_mount, file.original_filename)
+    FileUtils.touch(duplicate_file_path)
     FileUtils.cp(file.tempfile.path, duplicate_file_path)
     duplicate_file_path
   end

--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -110,6 +110,11 @@ class Api::ScormCoursesController < ApplicationController
     send_scorm_connect_response(response)
   end
 
+  def status
+    scorm_course = ScormCourse.find(params[:scorm_course_id])
+    render json: { scorm_course_id: scorm_course.id, status: scorm_course.import_job_status }
+  end
+
   private
 
   def validate_token_shared

--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -30,7 +30,10 @@ class Api::ScormCoursesController < ApplicationController
   end
 
   def create
-    scorm_course = ScormCourse.create(import_job_status: ScormCourse::CREATED)
+    scorm_course = ScormCourse.create(
+      import_job_status: ScormCourse::CREATED,
+      lms_course_id: params[:lms_course_id],
+    )
 
     storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.mktmpdir
 

--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -113,7 +113,6 @@ class Api::ScormCoursesController < ApplicationController
   def copy_to_storage(file)
     storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.mktmpdir
     duplicate_file_path = File.join(storage_mount, file.original_filename)
-    FileUtils.touch(duplicate_file_path)
     FileUtils.cp(file.tempfile.path, duplicate_file_path)
     duplicate_file_path
   end

--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -32,7 +32,9 @@ class Api::ScormCoursesController < ApplicationController
   def create
     scorm_course = ScormCourse.create(import_job_status: ScormCourse::CREATED)
 
-    output_file = File.join(Dir.mktmpdir, params[:file].original_filename)
+    storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.mktmpdir
+
+    output_file = File.join(storage_mount, params[:file].original_filename)
     duplicate = File.open(output_file, "wb")
     original_file = File.open(params[:file].tempfile, "rb")
     IO.copy_stream(original_file, duplicate)

--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -101,26 +101,28 @@ class Api::ScormCoursesController < ApplicationController
   end
 
   def replace
-    course = ScormCourse.find_by(scorm_service_id: params[:scorm_course_id])
-    course_id = get_course_id(params[:scorm_course_id])
-    response = scorm_connect_service(course_id).update_course(
-      params[:file],
-      course,
-    )
-    delete_canvas_file(course.file_id) if course&.file_id
-    file_id = upload_canvas_file(params[:file], params[:lms_course_id])
-    if file_id
-      course.update_attribute(:file_id, file_id)
-      hide_scorm_file(file_id)
-    end
-    if course.lms_assignment_id
-      update_canvas_assignment(
+    scorm_course = ScormCourse.find_by(scorm_service_id: params[:scorm_course_id])
+    scorm_course.update(import_job_status: ScormCourse::CREATED)
+
+    storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.mktmpdir
+
+    output_file = File.join(storage_mount, params[:file].original_filename)
+    duplicate = File.open(output_file, "wb")
+    original_file = File.open(params[:file].tempfile, "rb")
+    IO.copy_stream(original_file, duplicate)
+    duplicate.close
+    original_file.close
+
+    ScormImportJob.
+      perform_later(
+        current_application_instance,
+        current_user,
         params[:lms_course_id],
-        course.lms_assignment_id,
-        response[:response][:title],
+        scorm_course,
+        duplicate.path,
+        params[:file].original_filename,
       )
-    end
-    send_scorm_connect_response(response)
+    render json: { scorm_course_id: scorm_course.id }
   end
 
   def status
@@ -146,52 +148,5 @@ class Api::ScormCoursesController < ApplicationController
 
   def delete_canvas_file(file_id)
     canvas_api.proxy("DELETE_FILE", { id: file_id })
-  end
-
-  def upload_canvas_file(file, lms_course_id)
-    if file.is_a? ActionDispatch::Http::UploadedFile
-      canvas_response = canvas_api.proxy(
-        "COURSES_UPLOAD_FILE",
-        {
-          course_id: lms_course_id,
-        },
-        {
-          name: file.original_filename,
-          content_type: "application/zip",
-          parent_folder_path: "scorm_files/",
-          on_duplicate: "rename",
-        },
-      ).parsed_response
-      canvas_response["upload_params"]["file"] = File.new(file.tempfile)
-      RestClient.post(
-        canvas_response["upload_url"],
-        canvas_response["upload_params"],
-      ) do |response|
-        case response.code
-        when 200
-          JSON.parse(response.body)["id"]
-        when 302, 303
-          file_confirm = RestClient.get(response.headers[:location])
-          JSON.parse(file_confirm.body)["id"]
-        end
-      end
-    end
-  end
-
-  def hide_scorm_file(file_id)
-    canvas_api.proxy("UPDATE_FILE", { id: file_id }, { hidden: true })
-  end
-
-  def update_canvas_assignment(lms_course_id, assignment_id, name)
-    canvas_api.proxy(
-      "EDIT_ASSIGNMENT",
-      {
-        course_id: lms_course_id,
-        id: assignment_id,
-      },
-      {
-        assignment: { name: name },
-      },
-    )
   end
 end

--- a/app/helpers/scorm_course_helper.rb
+++ b/app/helpers/scorm_course_helper.rb
@@ -1,6 +1,6 @@
 module ScormCourseHelper
-  def scorm_connect_service(lms_course_id)
-    @service ||= if current_application_instance.scorm_type == "engine"
+  def scorm_connect_service(lms_course_id, app_instance = current_application_instance)
+    @service ||= if app_instance.scorm_type == "engine"
                    ScormEngineService.new(lms_course_id)
                  else
                    ScormCloudService.new

--- a/app/jobs/scorm_import_job.rb
+++ b/app/jobs/scorm_import_job.rb
@@ -16,7 +16,6 @@ class ScormImportJob < ApplicationJob
       upload_course(
         file_path,
         filename,
-        lms_course_id,
         scorm_course,
       )
 

--- a/app/jobs/scorm_import_job.rb
+++ b/app/jobs/scorm_import_job.rb
@@ -30,5 +30,8 @@ class ScormImportJob < ApplicationJob
         filename,
         response,
       )
+  rescue StandardError => e
+    scorm_course.update(import_job_status: ScormCourse::FAILED)
+    raise e
   end
 end

--- a/app/jobs/scorm_import_job.rb
+++ b/app/jobs/scorm_import_job.rb
@@ -12,15 +12,13 @@ class ScormImportJob < ApplicationJob
   )
     scorm_course.update(import_job_status: ScormCourse::RUNNING)
 
-    scorm_file = File.open(file_path)
     response = scorm_connect_service(lms_course_id, application_instance).
       upload_course(
-        scorm_file,
+        file_path,
         filename,
         lms_course_id,
         scorm_course,
       )
-    scorm_file.close
 
     ScormStatusCheckJob.
       perform_later(

--- a/app/jobs/scorm_import_job.rb
+++ b/app/jobs/scorm_import_job.rb
@@ -1,0 +1,36 @@
+class ScormImportJob < ApplicationJob
+  include ScormCourseHelper
+  queue_as :default
+
+  def perform(
+    application_instance,
+    user,
+    lms_course_id,
+    scorm_course,
+    file_path,
+    filename
+  )
+    scorm_course.update(import_job_status: ScormCourse::RUNNING)
+
+    scorm_file = File.open(file_path)
+    response = scorm_connect_service(lms_course_id, application_instance).
+      upload_course(
+        scorm_file,
+        filename,
+        lms_course_id,
+        scorm_course,
+      )
+    scorm_file.close
+
+    ScormStatusCheckJob.
+      perform_later(
+        application_instance,
+        user,
+        lms_course_id,
+        scorm_course,
+        file_path,
+        filename,
+        response,
+      )
+  end
+end

--- a/app/jobs/scorm_import_job.rb
+++ b/app/jobs/scorm_import_job.rb
@@ -7,15 +7,13 @@ class ScormImportJob < ApplicationJob
     user,
     lms_course_id,
     scorm_course,
-    file_path,
-    filename
+    file_path
   )
     scorm_course.update(import_job_status: ScormCourse::RUNNING)
 
     response = scorm_connect_service(lms_course_id, application_instance).
       upload_course(
         file_path,
-        filename,
         scorm_course,
       )
 
@@ -26,7 +24,6 @@ class ScormImportJob < ApplicationJob
         lms_course_id,
         scorm_course,
         file_path,
-        filename,
         response,
       )
   rescue StandardError => e

--- a/app/jobs/scorm_status_check_job.rb
+++ b/app/jobs/scorm_status_check_job.rb
@@ -8,7 +8,6 @@ class ScormStatusCheckJob < ApplicationJob
     lms_course_id,
     scorm_course,
     file_path,
-    filename,
     response
   )
     scorm_course.update(import_job_status: ScormCourse::RUNNING)
@@ -28,7 +27,6 @@ class ScormStatusCheckJob < ApplicationJob
         lms_course_id,
         scorm_course,
         file_path,
-        filename,
       )
   rescue StandardError => e
     scorm_course.update(import_job_status: ScormCourse::FAILED)

--- a/app/jobs/scorm_status_check_job.rb
+++ b/app/jobs/scorm_status_check_job.rb
@@ -18,7 +18,7 @@ class ScormStatusCheckJob < ApplicationJob
 
     raise Adhesion::Exceptions::ScormImport.new(status) if status != "COMPLETE"
 
-    title = scorm_service.get_scorm_title(response[:package_id])
+    title = scorm_service.get_scorm_title(scorm_course.scorm_service_id)
     scorm_course.update(title: title)
 
     UploadCanvasJob.

--- a/app/jobs/scorm_status_check_job.rb
+++ b/app/jobs/scorm_status_check_job.rb
@@ -11,6 +11,8 @@ class ScormStatusCheckJob < ApplicationJob
     filename,
     response
   )
+    scorm_course.update(import_job_status: ScormCourse::RUNNING)
+
     scorm_service = scorm_connect_service(lms_course_id, application_instance)
     status = scorm_service.check_import_progress(response[:import_job_id])
 
@@ -28,5 +30,8 @@ class ScormStatusCheckJob < ApplicationJob
         file_path,
         filename,
       )
+  rescue StandardError => e
+    scorm_course.update(import_job_status: ScormCourse::FAILED)
+    raise e
   end
 end

--- a/app/jobs/scorm_status_check_job.rb
+++ b/app/jobs/scorm_status_check_job.rb
@@ -1,0 +1,32 @@
+class ScormStatusCheckJob < ApplicationJob
+  include ScormCourseHelper
+  queue_as :default
+
+  def perform(
+    application_instance,
+    user,
+    lms_course_id,
+    scorm_course,
+    file_path,
+    filename,
+    response
+  )
+    scorm_service = scorm_connect_service(lms_course_id, application_instance)
+    status = scorm_service.check_import_progress(response[:import_job_id])
+
+    raise Adhesion::Exceptions::ScormImport.new(status) if status != "COMPLETE"
+
+    title = scorm_service.get_scorm_title(response[:package_id])
+    scorm_course.update(title: title)
+
+    UploadCanvasJob.
+      perform_later(
+        application_instance,
+        user,
+        lms_course_id,
+        scorm_course,
+        file_path,
+        filename,
+      )
+  end
+end

--- a/app/jobs/upload_canvas_job.rb
+++ b/app/jobs/upload_canvas_job.rb
@@ -1,0 +1,69 @@
+class UploadCanvasJob < ApplicationJob
+  include Concerns::CanvasSupport
+  include ScormCourseHelper
+  queue_as :default
+
+  def perform(
+    application_instance,
+    current_user,
+    lms_course_id,
+    scorm_course,
+    file_path,
+    filename
+  )
+    current_course = Course.find_by(lms_course_id: lms_course_id)
+    @canvas_api = canvas_api(
+      application_instance: application_instance,
+      user: current_user,
+      course: current_course,
+    )
+    scorm_file = File.open(file_path)
+    file_id = upload_canvas_file(file_path, filename, lms_course_id)
+
+    if file_id
+      hide_scorm_file(file_id)
+      scorm_course.update(
+        file_id: file_id,
+        import_job_status: ScormCourse::COMPLETE,
+      )
+    else
+      scorm_course.update(ScormCourse::FAILED)
+    end
+
+    FileUtils.remove_entry_secure(scorm_file)
+  end
+
+  def upload_canvas_file(file_path, filename, lms_course_id)
+    if file_path.present?
+      canvas_response = @canvas_api.proxy(
+        "COURSES_UPLOAD_FILE",
+        {
+          course_id: lms_course_id,
+        },
+        {
+          name: filename,
+          content_type: "application/zip",
+          parent_folder_path: "scorm_files/",
+          on_duplicate: "rename",
+        },
+      ).parsed_response
+      canvas_response["upload_params"]["file"] = File.new(file_path)
+      RestClient.post(
+        canvas_response["upload_url"],
+        canvas_response["upload_params"],
+      ) do |response|
+        case response.code
+        when 200
+          JSON.parse(response.body)["id"]
+        when 302, 303
+          file_confirm = RestClient.get(response.headers[:location])
+          JSON.parse(file_confirm.body)["id"]
+        end
+      end
+    end
+  end
+
+  def hide_scorm_file(file_id)
+    @canvas_api.proxy("UPDATE_FILE", { id: file_id }, { hidden: true })
+  end
+end

--- a/app/jobs/upload_canvas_job.rb
+++ b/app/jobs/upload_canvas_job.rb
@@ -8,8 +8,7 @@ class UploadCanvasJob < ApplicationJob
     current_user,
     lms_course_id,
     scorm_course,
-    file_path,
-    filename
+    file_path
   )
     scorm_course.update(import_job_status: ScormCourse::RUNNING)
 
@@ -21,7 +20,7 @@ class UploadCanvasJob < ApplicationJob
     )
 
     delete_canvas_file(scorm_course.file_id) if scorm_course&.file_id
-    file_id = upload_canvas_file(file_path, filename, lms_course_id)
+    file_id = upload_canvas_file(file_path, lms_course_id)
     if file_id
       hide_scorm_file(file_id)
       scorm_course.update(
@@ -46,7 +45,7 @@ class UploadCanvasJob < ApplicationJob
     raise e
   end
 
-  def upload_canvas_file(file_path, filename, lms_course_id)
+  def upload_canvas_file(file_path, lms_course_id)
     if file_path.present?
       canvas_response = @canvas_api.proxy(
         "COURSES_UPLOAD_FILE",
@@ -54,7 +53,7 @@ class UploadCanvasJob < ApplicationJob
           course_id: lms_course_id,
         },
         {
-          name: filename,
+          name: File.basename(file_path),
           content_type: "application/zip",
           parent_folder_path: "scorm_files/",
           on_duplicate: "rename",

--- a/app/jobs/upload_canvas_job.rb
+++ b/app/jobs/upload_canvas_job.rb
@@ -31,8 +31,6 @@ class UploadCanvasJob < ApplicationJob
       raise Adhesion::Exceptions::ScormCanvasUpload.new
     end
 
-    FileUtils.remove_entry_secure(file_path)
-
     if scorm_course.lms_assignment_id.present?
       update_canvas_assignment(
         lms_course_id,
@@ -40,6 +38,8 @@ class UploadCanvasJob < ApplicationJob
         scorm_course.title,
       )
     end
+
+    FileUtils.remove_entry_secure(file_path)
   rescue StandardError => e
     scorm_course.update(import_job_status: ScormCourse::FAILED)
     raise e

--- a/app/lib/adhesion/exceptions.rb
+++ b/app/lib/adhesion/exceptions.rb
@@ -5,5 +5,11 @@ module Adhesion
         super(msg)
       end
     end
+
+    class ScormCanvasUpload < StandardError
+      def initialize(msg = "Error with Scorm Canvas Upload")
+        super(msg)
+      end
+    end
   end
 end

--- a/app/models/scorm_course.rb
+++ b/app/models/scorm_course.rb
@@ -5,6 +5,11 @@ class ScormCourse < ActiveRecord::Base
 
   after_commit :set_scorm_service_id, on: [:create]
 
+  CREATED = "CREATED".freeze
+  RUNNING = "RUNNING".freeze
+  COMPLETE = "COMPLETE".freeze
+  FAILED = "FAILED".freeze
+
   def regs
     @regs ||= registrations.includes(:scorm_activities)
   end

--- a/app/models/scorm_course.rb
+++ b/app/models/scorm_course.rb
@@ -5,6 +5,8 @@ class ScormCourse < ActiveRecord::Base
 
   after_commit :set_scorm_service_id, on: [:create]
 
+  attr_accessor :lms_course_id
+
   CREATED = "CREATED".freeze
   RUNNING = "RUNNING".freeze
   COMPLETE = "COMPLETE".freeze
@@ -15,7 +17,8 @@ class ScormCourse < ActiveRecord::Base
   end
 
   def set_scorm_service_id
-    self.scorm_service_id = id if scorm_service_id.blank?
+    package_id = "#{id}_#{lms_course_id}"
+    self.scorm_service_id = package_id if scorm_service_id.blank?
     save if scorm_service_id_changed?
   end
 

--- a/app/services/scorm_common_service.rb
+++ b/app/services/scorm_common_service.rb
@@ -21,11 +21,10 @@ module ScormCommonService
     end
   end
 
-  def upload_course(file, filename, scorm_course)
+  def upload_course(file, scorm_course)
     cleanup = Proc.new { scorm_course.destroy }
     import_job_id = upload_scorm_course(
       file,
-      filename,
       scorm_course.scorm_service_id,
       cleanup,
     )

--- a/app/services/scorm_common_service.rb
+++ b/app/services/scorm_common_service.rb
@@ -21,18 +21,17 @@ module ScormCommonService
     end
   end
 
-  def upload_course(file, lms_course_id)
-    course = ScormCourse.create
-    cleanup = Proc.new { course.destroy }
-    package_id = "#{course.id}_#{lms_course_id}"
-    response = upload_scorm_course(file, package_id, cleanup)
-    course.update_attributes(
-      title: response[:response][:title],
-      scorm_service_id: package_id,
-    )
-    response["course_id"] = course.id
-    response["package_id"] = package_id
-    response
+  def upload_course(file, filename, lms_course_id, scorm_course)
+    cleanup = Proc.new { scorm_course.destroy }
+    package_id = "#{scorm_course.id}_#{lms_course_id}"
+    import_job_id = upload_scorm_course(file, filename, package_id, cleanup)
+    scorm_course.update(scorm_service_id: package_id)
+
+    {
+      scorm_course_id: scorm_course.id,
+      package_id: package_id,
+      import_job_id: import_job_id,
+    }
   end
 
   def update_course(file, course)

--- a/app/services/scorm_common_service.rb
+++ b/app/services/scorm_common_service.rb
@@ -21,23 +21,19 @@ module ScormCommonService
     end
   end
 
-  def upload_course(file, filename, lms_course_id, scorm_course)
+  def upload_course(file, filename, scorm_course)
     cleanup = Proc.new { scorm_course.destroy }
-    package_id = "#{scorm_course.id}_#{lms_course_id}"
-    import_job_id = upload_scorm_course(file, filename, package_id, cleanup)
-    scorm_course.update(scorm_service_id: package_id)
+    import_job_id = upload_scorm_course(
+      file,
+      filename,
+      scorm_course.scorm_service_id,
+      cleanup,
+    )
 
     {
       scorm_course_id: scorm_course.id,
-      package_id: package_id,
       import_job_id: import_job_id,
     }
-  end
-
-  def update_course(file, course)
-    response = update_scorm_course(file, course.scorm_service_id)
-    course.update_attribute(:title, response[:response][:title])
-    response
   end
 
   def remove_course(course_id)

--- a/app/services/scorm_engine_service.rb
+++ b/app/services/scorm_engine_service.rb
@@ -44,15 +44,15 @@ class ScormEngineService
     courses
   end
 
-  def upload_scorm_course(file, filename, course_id, _cleanup)
-    import_course(file, filename, course_id)
+  def upload_scorm_course(file, course_id, _cleanup)
+    import_course(file, course_id)
   end
 
-  def update_scorm_course(file, filename, course_id)
-    import_course(file, filename, course_id)
+  def update_scorm_course(file, course_id)
+    import_course(file, course_id)
   end
 
-  def import_course(file, filename, course_id)
+  def import_course(file, course_id)
     params = {
       course: course_id,
       mayCreateNewVersion: true,
@@ -66,7 +66,7 @@ class ScormEngineService
         user: @api_username,
         password: @api_password,
         payload: {
-          file: UploadIO.new(zip, "zip/zip", filename),
+          file: UploadIO.new(zip, "zip/zip", File.basename(file)),
         },
       ) do |response|
         raise response if response.code == 500

--- a/app/services/scorm_engine_service.rb
+++ b/app/services/scorm_engine_service.rb
@@ -59,7 +59,7 @@ class ScormEngineService
     }.to_query
     url = "#{@scorm_tenant_url}/courses/importJobs?#{params}"
 
-    File.open(File.new(file.path)) do |zip|
+    File.open(file) do |zip|
       RestClient::Request.execute(
         method: :post,
         url: url,

--- a/app/services/scorm_engine_service.rb
+++ b/app/services/scorm_engine_service.rb
@@ -44,15 +44,15 @@ class ScormEngineService
     courses
   end
 
-  def upload_scorm_course(file, course_id, _cleanup)
-    import_course(file, course_id)
+  def upload_scorm_course(file, filename, course_id, _cleanup)
+    import_course(file, filename, course_id)
   end
 
-  def update_scorm_course(file, course_id)
-    import_course(file, course_id)
+  def update_scorm_course(file, filename, course_id)
+    import_course(file, filename, course_id)
   end
 
-  def import_course(file, course_id)
+  def import_course(file, filename, course_id)
     params = {
       course: course_id,
       mayCreateNewVersion: true,
@@ -66,21 +66,11 @@ class ScormEngineService
         user: @api_username,
         password: @api_password,
         payload: {
-          file: UploadIO.new(zip, "zip/zip", file.original_filename),
+          file: UploadIO.new(zip, "zip/zip", filename),
         },
       ) do |response|
         raise response if response.code == 500
-        import_job_id = JSON.parse(response.body)["result"]
-        import_status = check_import_progress(import_job_id)
-        course = {}
-        course[:response] = {}
-        course[:response][:title] = get_scorm_title(course_id)
-        course[:status] = if import_status == "COMPLETE"
-                            200
-                          else
-                            500
-                          end
-        course
+        JSON.parse(response.body)["result"]
       end
     end
   end

--- a/client/apps/scorm/actions/scorm.js
+++ b/client/apps/scorm/actions/scorm.js
@@ -16,6 +16,7 @@ const requests = [
   'PREVIEW_PACKAGE',
   'UPDATE_PACKAGE',
   'REPLACE_PACKAGE',
+  'POLL_STATUS',
 ];
 
 export const Constants = wrapper(actions, requests);
@@ -31,6 +32,12 @@ export const loadPackages = lmsCourseId => ({
   type: Constants.LOAD_PACKAGES,
   url: '/api/scorm_courses',
   params: { lms_course_id: lmsCourseId },
+});
+
+export const pollStatus = scormCourseId => ({
+  method: Network.GET,
+  type: Constants.POLL_STATUS,
+  url: `/api/scorm_courses/${scormCourseId}/status`,
 });
 
 export const uploadPackage = (file, lmsCourseId) => {

--- a/client/apps/scorm/components/scorm/_scorm_index.jsx
+++ b/client/apps/scorm/components/scorm/_scorm_index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import {
@@ -14,28 +15,29 @@ import * as ModalActions from '../../../../libs/actions/modal';
 export class ScormIndex extends React.Component {
 
   static propTypes = {
-    loadPackages: React.PropTypes.func,
-    canvasRequest: React.PropTypes.func,
-    removePackage: React.PropTypes.func,
-    uploadPackage: React.PropTypes.func,
-    previewPackage: React.PropTypes.func,
-    replacePackage: React.PropTypes.func,
-    updateImportType: React.PropTypes.func,
-    removeError: React.PropTypes.func,
-    lmsCourseId: React.PropTypes.string,
-    scormList: React.PropTypes.arrayOf(React.PropTypes.object),
-    canvasAssignments: React.PropTypes.shape({}),
-    listAssignmentsDone: React.PropTypes.bool,
-    shouldRefreshList: React.PropTypes.bool,
-    apiUrl: React.PropTypes.string,
-    scormFile: React.PropTypes.shape({}),
-    canvasUrl: React.PropTypes.string.isRequired,
-    loadError: React.PropTypes.bool,
-    hideModal: React.PropTypes.func.isRequired,
-    showModal: React.PropTypes.func.isRequired,
-    location: React.PropTypes.shape({
-      query: React.PropTypes.shape({
-        noSync: React.PropTypes.string,
+    loadPackages: PropTypes.func,
+    canvasRequest: PropTypes.func,
+    removePackage: PropTypes.func,
+    uploadPackage: PropTypes.func,
+    previewPackage: PropTypes.func,
+    replacePackage: PropTypes.func,
+    updateImportType: PropTypes.func,
+    removeError: PropTypes.func,
+    lmsCourseId: PropTypes.string,
+    scormList: PropTypes.arrayOf(PropTypes.object),
+    canvasAssignments: PropTypes.shape({}),
+    listAssignmentsDone: PropTypes.bool,
+    shouldRefreshList: PropTypes.bool,
+    scormCourseId: PropTypes.number,
+    apiUrl: PropTypes.string,
+    scormFile: PropTypes.shape({}),
+    canvasUrl: PropTypes.string.isRequired,
+    loadError: PropTypes.bool,
+    hideModal: PropTypes.func.isRequired,
+    showModal: PropTypes.func.isRequired,
+    location: PropTypes.shape({
+      query: PropTypes.shape({
+        noSync: PropTypes.string,
       }),
     }),
   };
@@ -56,6 +58,11 @@ export class ScormIndex extends React.Component {
   }
 
   componentDidUpdate() {
+    if (this.props.shouldPollStatus) {
+      _.delay(() => {
+        this.props.pollStatus(this.props.scormCourseId);
+      }, 5000);
+    }
     if (this.props.shouldRefreshList) {
       this.props.loadPackages(this.props.lmsCourseId);
     }
@@ -184,9 +191,10 @@ const select = (state) => {
     apiUrl: state.settings.api_url,
     scormList: courseList,
     shouldRefreshList: state.scorm.shouldRefreshList,
+    shouldPollStatus: state.scorm.shouldPollStatus,
+    scormCourseId: state.scorm.scormCourseId,
     scormFile: state.scorm.file,
     loadError: state.scorm.loadError,
-    uploadError: state.scorm.uploadError,
     canvasAssignments: state.scorm.canvasAssignments,
     listAssignmentsDone: state.scorm.listAssignmentsDone,
     canvasUrl: state.settings.custom_canvas_api_domain,

--- a/client/apps/scorm/reducers/scorm.js
+++ b/client/apps/scorm/reducers/scorm.js
@@ -126,8 +126,11 @@ export default (state = initialState, action) => {
       return { ...state, scormList: updatedScormList };
     }
 
-    case PackageConstants.REPLACE_PACKAGE_DONE:
-      return { ...state, shouldRefreshList: true };
+    case PackageConstants.REPLACE_PACKAGE_DONE: {
+      const scormCourseId = action.payload ? action.payload.scorm_course_id : null;
+      const shouldPollStatus = !!scormCourseId;
+      return { ...state, scormCourseId, shouldPollStatus };
+    }
 
     default:
       return state;

--- a/client/apps/scorm/reducers/scorm.js
+++ b/client/apps/scorm/reducers/scorm.js
@@ -65,8 +65,7 @@ export default (state = initialState, action) => {
 
     case PackageConstants.UPLOAD_PACKAGE: {
       const file = action.upload;
-      const showUpload = true;
-      return { ...state, showUploading: showUpload, file };
+      return { ...state, file };
     }
     case PackageConstants.REMOVE_PACKAGE: {
       const newState = _.cloneDeep(state);
@@ -85,7 +84,33 @@ export default (state = initialState, action) => {
           errorText,
         };
       }
-      return { ...state, file: null, shouldRefreshList: true };
+      const scormCourseId = action.payload ? action.payload.scorm_course_id : null;
+      const shouldPollStatus = !!scormCourseId;
+      return { ...state, scormCourseId, shouldPollStatus };
+    }
+    case PackageConstants.POLL_STATUS_DONE: {
+      const {
+        status,
+        scorm_course_id:scormCourseId,
+      } = action.payload;
+
+      const shouldPollStatus = !_.includes(['COMPLETE', 'FAILED'], status);
+      let shouldRefreshList = !shouldPollStatus;
+      let errorText = '';
+      let uploadError = false;
+      if (status === 'FAILED') {
+        uploadError = true;
+        errorText = status;
+        shouldRefreshList = false;
+      }
+      return {
+        ...state,
+        scormCourseId,
+        shouldPollStatus,
+        shouldRefreshList,
+        uploadError,
+        errorText,
+      };
     }
     case PackageConstants.UPDATE_UPLOAD_FILE:
       return { ...state, file: action.file };

--- a/client/apps/scorm/reducers/scorm.spec.js
+++ b/client/apps/scorm/reducers/scorm.spec.js
@@ -41,7 +41,6 @@ describe('scorm reducer', () => {
     let file;
     action.upload = { file };
     const newState = reducer(state, action);
-    expect(newState.showUploading).toBeTruthy();
     expect(newState.file).toBeDefined();
   });
 

--- a/client/apps/scorm/reducers/scorm.spec.js
+++ b/client/apps/scorm/reducers/scorm.spec.js
@@ -55,8 +55,10 @@ describe('scorm reducer', () => {
   it('should handle UPLOAD_PACKAGE_DONE without an error', () => {
     action.type = Constants.UPLOAD_PACKAGE_DONE;
     action.error = false;
+    action.payload = {};
+    action.payload.scorm_course_id = 123;
     const newState = reducer(state, action);
-    expect(newState.shouldRefreshList).toBeTruthy();
+    expect(newState.shouldPollStatus).toBeTruthy();
   });
 
   it('should handle UPDATE_UPLOAD_FILE', () => {

--- a/config/initializers/nuclear_secrets.rb
+++ b/config/initializers/nuclear_secrets.rb
@@ -31,5 +31,6 @@ NuclearSecrets.configure do |config|
     u4sm_url: String,
     u4sm_username: String,
     u4sm_password: String,
+    storage_mount: String,
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
       get "activity_report" => "scorm_courses#activity_report"
       get "launch" => "scorm_courses#launch"
       get "preview" => "scorm_courses#preview"
+      get "status" => "scorm_courses#status"
       post "import" => "scorm_courses#import"
       post "replace" => "scorm_courses#replace"
       resources :students, only: [:index]

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -51,6 +51,8 @@ Defaults: &defaults
   u4sm_url: "https://example.com"
   u4sm_username: "username"
   u4sm_password: "password"
+
+  storage_mount: ""
 development:
   <<: *defaults
 

--- a/db/migrate/20171211225415_add_import_job_status_to_scorm_course.rb
+++ b/db/migrate/20171211225415_add_import_job_status_to_scorm_course.rb
@@ -1,0 +1,5 @@
+class AddImportJobStatusToScormCourse < ActiveRecord::Migration[5.0]
+  def change
+    add_column :scorm_courses, :import_job_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171023190624) do
+ActiveRecord::Schema.define(version: 20171211225415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -262,6 +262,7 @@ ActiveRecord::Schema.define(version: 20171023190624) do
     t.string   "scorm_service_id"
     t.string   "title"
     t.bigint   "file_id"
+    t.string   "import_job_status"
     t.index ["lms_assignment_id"], name: "index_scorm_courses_on_lms_assignment_id", using: :btree
     t.index ["scorm_service_id"], name: "index_scorm_courses_on_scorm_service_id", unique: true, using: :btree
   end

--- a/spec/controllers/api/scorm_courses_controller_spec.rb
+++ b/spec/controllers/api/scorm_courses_controller_spec.rb
@@ -88,6 +88,16 @@ RSpec.describe Api::ScormCoursesController, type: :controller do
     end
   end
 
+  describe "GET status" do
+    it "should return the status" do
+      scorm_course = create(:scorm_course, import_job_status: "RUNNING")
+      get :status, scorm_course_id: scorm_course.id
+      expect(response).to have_http_status 200
+      expected = { "scorm_course_id" => scorm_course.id, "status" => "RUNNING" }
+      expect(JSON.parse(response.body)).to eq(expected)
+    end
+  end
+
   describe "GET course_report" do
     it "should return course analytics data" do
       course = ScormCourse.create

--- a/spec/controllers/api/scorm_courses_controller_spec.rb
+++ b/spec/controllers/api/scorm_courses_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Api::ScormCoursesController, type: :controller do
 
       file = Foo.new
 
-      allow(controller).to receive(:copy_file).and_return(file)
+      allow(controller).to receive(:copy_to_storage).and_return(file)
 
       post :create, file: "fake_file", lms_course_id: "course_id"
       expect(response).to have_http_status(200)

--- a/spec/models/scorm_course_spec.rb
+++ b/spec/models/scorm_course_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe ScormCourse, type: :model do
   describe "#regs" do
     before do
-      @scorm_course = ScormCourse.create
+      @lms_course_id = generate(:lms_course_id)
+      @scorm_course = ScormCourse.create(lms_course_id: @lms_course_id)
     end
 
     it "sets registration" do
@@ -11,7 +12,7 @@ RSpec.describe ScormCourse, type: :model do
     end
 
     it "sets registration" do
-      registration = Registration.create(lms_course_id: @scorm_course.id)
+      registration = Registration.create(lms_course_id: @scorm_course.scorm_service_id)
       report = JSON.parse(File.read("spec/fixtures/json/report.json"))
       report = report.deep_symbolize_keys
       registration.store_activities(report[:registrationreport][:activity])
@@ -21,10 +22,11 @@ RSpec.describe ScormCourse, type: :model do
 
   describe "#set_scorm_service_id" do
     it "should set the scorm_service_id" do
-      scorm_course = ScormCourse.new
+      scorm_course = ScormCourse.new(lms_course_id: @lms_course_id)
       expect(scorm_course.scorm_service_id).to eq(nil)
       scorm_course.save!
-      expect(scorm_course.scorm_service_id).to eq(scorm_course.id.to_s)
+      scorm_service_id = "#{scorm_course.id}_#{@lms_course_id}"
+      expect(scorm_course.scorm_service_id).to eq(scorm_service_id)
     end
   end
 
@@ -79,7 +81,7 @@ RSpec.describe ScormCourse, type: :model do
 
     describe "with registration code" do
       before do
-        registration = Registration.create(lms_course_id: @scorm_course.id)
+        registration = Registration.create(lms_course_id: @scorm_course.scorm_service_id)
         report = JSON.parse(File.read("spec/fixtures/json/report.json"))
         report = report.deep_symbolize_keys
         registration.store_activities(report[:registrationreport][:activity])
@@ -141,7 +143,7 @@ RSpec.describe ScormCourse, type: :model do
     end
 
     it "should return the course activities with analytics table" do
-      registration = Registration.create(lms_course_id: @scorm_course.id)
+      registration = Registration.create(lms_course_id: @scorm_course.scorm_service_id)
       report = JSON.parse(File.read("spec/fixtures/json/report.json"))
       report = report.deep_symbolize_keys
       registration.store_activities(report[:registrationreport][:activity])
@@ -151,7 +153,7 @@ RSpec.describe ScormCourse, type: :model do
     end
 
     it "should contain correct analytics table" do
-      registration = Registration.create(lms_course_id: @scorm_course.id)
+      registration = Registration.create(lms_course_id: @scorm_course.scorm_service_id)
       report = JSON.parse(File.read("spec/fixtures/json/report.json"))
       report = report.deep_symbolize_keys
       registration.store_activities(report[:registrationreport][:activity])


### PR DESCRIPTION
* Add import_job_status to scorm_courses
* Add workers to upload scorm courses
* Don’t open the file so many times
* Add scorm course status route
* Copy upload into temp file to ensure it stays around after the web request goes away
* Update job status if something fails
* Add ability to poll scorm course import status
* Use a configurable storage mount
* Set the scorm_service_id correctly on creation
* Pass in lms_course_id when creating ScormCourse record
* Update replace scorm package to use background workers