### PR TITLE
Improve scorm uploads

### DIFF
--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -111,7 +111,7 @@ class Api::ScormCoursesController < ApplicationController
   end
 
   def copy_to_storage(file)
-    storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.mktmpdir
+    storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.tmpdir
     duplicate_file_path = File.join(storage_mount, file.original_filename)
     FileUtils.cp(file.tempfile.path, duplicate_file_path)
     duplicate_file_path

--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -113,7 +113,7 @@ class Api::ScormCoursesController < ApplicationController
   def copy_to_storage(file)
     storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.tmpdir
     duplicate_file_path = File.join(storage_mount, file.original_filename)
-    FileUtils.cp(file.tempfile.path, duplicate_file_path)
+    Thread.new { FileUtils.cp(file.tempfile.path, duplicate_file_path) }
     duplicate_file_path
   end
 

--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -113,7 +113,20 @@ class Api::ScormCoursesController < ApplicationController
   def copy_to_storage(file)
     storage_mount = Rails.env.production? ? Rails.application.secrets.storage_mount : Dir.tmpdir
     duplicate_file_path = File.join(storage_mount, file.original_filename)
-    Thread.new { FileUtils.cp(file.tempfile.path, duplicate_file_path) }
+    Thread.new do
+      begin
+        FileUtils.cp(file.tempfile.path, duplicate_file_path)
+      rescue StandardError => e
+        log = <<~DOC
+          SCORM upload failed to copy to storage.
+          tempfile: #{file.tempfile.path}
+          duplicate_file_path: #{duplicate_file_path}
+          e: #{e}
+        DOC
+        logger.error log
+        raise e
+      end
+    end
     duplicate_file_path
   end
 

--- a/app/jobs/scorm_import_job.rb
+++ b/app/jobs/scorm_import_job.rb
@@ -26,6 +26,10 @@ class ScormImportJob < ApplicationJob
         file_path,
         response,
       )
+  rescue Errno::ENOENT => e
+    # Don't mark the scorm course as failed as the file might
+    # not be copied to storage yet
+    raise e
   rescue StandardError => e
     scorm_course.update(import_job_status: ScormCourse::FAILED)
     raise e

--- a/config/initializers/rack.rb
+++ b/config/initializers/rack.rb
@@ -1,0 +1,9 @@
+# Dirty hack until rack gem is > 2.0.3
+# https://github.com/rack/rack/issues/1075
+# The middleware approach was not reliable.
+# Setting the const, in my tests, is always reliable.
+# This makes large file uploads process MUCH faster
+# The new rack code sets this to 1_048_576 so I think this
+# hack is still a better approach for this scenario with
+# huge scorm files.
+Rack::Multipart::Parser.const_set("BUFSIZE", 100 * 1024 * 1024)


### PR DESCRIPTION
* Add rack initializer to set the buffer size higher
* Use the tmp dir, don’t create new dirs.
* Copy the file to storage in a separate thread