### PR TITLE
Better scorm file uploads

### DIFF
--- a/app/controllers/api/scorm_courses_controller.rb
+++ b/app/controllers/api/scorm_courses_controller.rb
@@ -115,11 +115,11 @@ class Api::ScormCoursesController < ApplicationController
     duplicate_dir_path = File.join(storage_mount, "job", scorm_course_id.to_s)
     cmd = "mkdir -p #{duplicate_dir_path}"
     success = system(cmd)
-    raise ScormCopyToStorage unless success
+    raise Adhesion::Exceptions::ScormCopyToStorage unless success
     duplicate_file_path = File.join(duplicate_dir_path, file.original_filename)
     cmd = "mv #{file.tempfile.path} #{duplicate_file_path}"
     success = system(cmd)
-    raise ScormCopyToStorage unless success
+    raise Adhesion::Exceptions::ScormCopyToStorage unless success
     duplicate_file_path
   end
 

--- a/app/jobs/scorm_import_job.rb
+++ b/app/jobs/scorm_import_job.rb
@@ -26,10 +26,6 @@ class ScormImportJob < ApplicationJob
         file_path,
         response,
       )
-  rescue Errno::ENOENT => e
-    # Don't mark the scorm course as failed as the file might
-    # not be copied to storage yet
-    raise e
   rescue StandardError => e
     scorm_course.update(import_job_status: ScormCourse::FAILED)
     raise e

--- a/app/lib/adhesion/exceptions.rb
+++ b/app/lib/adhesion/exceptions.rb
@@ -11,5 +11,11 @@ module Adhesion
         super(msg)
       end
     end
+
+    class ScormCopyToStorage < StandardError
+      def initialize(msg = "Error with copying to storage")
+        super(msg)
+      end
+    end
   end
 end

--- a/config/initializers/rack.rb
+++ b/config/initializers/rack.rb
@@ -2,8 +2,4 @@
 # https://github.com/rack/rack/issues/1075
 # The middleware approach was not reliable.
 # Setting the const, in my tests, is always reliable.
-# This makes large file uploads process MUCH faster
-# The new rack code sets this to 1_048_576 so I think this
-# hack is still a better approach for this scenario with
-# huge scorm files.
-Rack::Multipart::Parser.const_set("BUFSIZE", 100 * 1024 * 1024)
+Rack::Multipart::Parser.const_set("BUFSIZE", 1024 * 1024)

--- a/config/initializers/tmp_dir.rb
+++ b/config/initializers/tmp_dir.rb
@@ -1,0 +1,14 @@
+# Override tmp dir for production deploys
+class Dir
+  class << self
+    alias :old_tmpdir :tmpdir
+
+    def tmpdir
+      if Rails.env.production?
+        File.join(Rails.application.secrets.storage_mount, "tmp")
+      else
+        old_tmpdir
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Remove thread
  * Shell out and make system commands to mv the temp file
  * mv file into a `job/<scorm_course_id>/` dir
* Reduce the buffer from 100 MB to 1 MB
* Override Dir.tmpdir and append “tmp” to end of tmpdir in production