### PR TITLE
Adjust skip_confirmation before commiting User to database

### DIFF
--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -103,6 +103,7 @@ module Concerns
       end
 
       user = User.new(email: email, name: name)
+      user.skip_confirmation!
       user.password = ::SecureRandom::hex(15)
       user.password_confirmation = user.password
       user.lti_user_id = lti_user_id
@@ -110,7 +111,6 @@ module Concerns
       user.lms_user_id = params[:custom_canvas_user_id] || params[:user_id]
       user.create_method = User.create_methods[:oauth]
       user.add_to_role("canvas_oauth_user")
-      user.skip_confirmation!
 
       # store lti roles for the user
       _add_roles(user, params)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -141,9 +141,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def find_using_oauth
     return if @user # Previous filter was successful and we already have a user
     if @user = User.for_auth(request.env["omniauth.auth"])
+      @user.skip_confirmation!
       kind = params[:action].titleize
       @user.update_oauth(request.env["omniauth.auth"])
-      @user.skip_confirmation!
       if kind == "Canvas"
         @user.add_to_role("canvas_oauth_user")
       end
@@ -157,12 +157,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     auth = request.env["omniauth.auth"]
     kind = params[:action].titleize # Should give us Facebook, Twitter, Linked In, etc
     @user = User.new
+    @user.skip_confirmation!
     @user.password = SecureRandom.hex(15)
     @user.password_confirmation = @user.password
     @user.create_method = User.create_methods[:oauth]
     @user.lti_user_id = auth["extra"]["raw_info"]["lti_user_id"]
     @user.apply_oauth(auth)
-    @user.skip_confirmation!
     if kind == "Canvas"
       @user.add_to_role("canvas_oauth_user")
     end


### PR DESCRIPTION
This is to fix when adhesion sends emails to confirm account user on lti_launches.  This wasn't immediately evident when testing locally.  To test, enable emails on local machine and look at the log for the lti_launch to determine if devise is attempting to send a confirmation email.

add_to_role function commits user to database and sends confirmation email before calling skip_confirmation