### PR TITLE
Remove secret_token from nuclear secrets required

### DIFF
--- a/config/initializers/nuclear_secrets.rb
+++ b/config/initializers/nuclear_secrets.rb
@@ -19,7 +19,6 @@ NuclearSecrets.configure do |config|
     auth0_client_secret: String,
     shared_auth_secret: String,
     secret_key_base: String,
-    secret_token: NilClass,
     canvas_proctor_url: String,
     scorm_url: String,
     scorm_api_path: String,


### PR DESCRIPTION
It is optional, hence why it was a NilClass. We can now remove it with the upgraded nuclear_secrets gem.