### PR TITLE
Fix error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
     @backtrace = e.backtrace
     @status = ActionDispatch::ExceptionWrapper.new(request.env, e).status_code
 
-    ErrorMailer.error_email(current_user, error_info).deliver_later
+    ErrorMailer.error_email(current_user, error_info.to_json).deliver_later
 
     respond_to do |format|
       format.html { render_html_error }
@@ -81,6 +81,10 @@ class ApplicationController < ActionController::Base
     if params_dup["user"].present?
       params_dup["user"]["password"] = "******"
     end
+    if params_dup["file"].present?
+      params_dup["file"] = params_dup["file"].headers
+    end
+
     {
       user_id: current_user&.id,
       user_email: current_user&.email,

--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -1,7 +1,7 @@
 class ErrorMailer < ApplicationMailer
   def error_email(user, error_info)
     @user = user
-    @error_info = error_info
+    @error_info = JSON.parse(error_info).with_indifferent_access
 
     mail(
       to: Rails.application.secrets.error_email,

--- a/spec/mailers/error_mailer_spec.rb
+++ b/spec/mailers/error_mailer_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ErrorMailer, type: :mailer do
         exception: "you did : something wrong",
         backtrace: backtrace,
       }
-      ErrorMailer.error_email(user, error_info)
+      ErrorMailer.error_email(user, error_info.to_json)
     end
 
     it "renders the headers" do


### PR DESCRIPTION
* Don’t try to serialize the uploaded file, just grab the headers and stick those into the error hash
* Enqueue ErrorMailer with json data and parse that json in the mailer
  * Don’t let it try to serialize the data for us, we will handle the data instead.