### PR TITLE
Set the FROM to the same as the TO for sending error emails

### DIFF
--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -4,6 +4,7 @@ class ErrorMailer < ApplicationMailer
     @error_info = JSON.parse(error_info).with_indifferent_access
 
     mail(
+      from: Rails.application.secrets.error_email,
       to: Rails.application.secrets.error_email,
       subject: @error_info[:exception],
     )

--- a/spec/mailers/error_mailer_spec.rb
+++ b/spec/mailers/error_mailer_spec.rb
@@ -55,7 +55,9 @@ RSpec.describe ErrorMailer, type: :mailer do
 
     it "renders the headers" do
       expect(mail.subject).to eq("you did : something wrong")
-      expect(mail.from).to eq(nil) # We want sendmail to assign the from value
+      # We wanted sendmail to assign the from value,
+      # however rails won't let us leave the from value blank
+      expect(mail.from).to eq([])
     end
 
     it "renders the body" do


### PR DESCRIPTION
Rails apparently requires this in production mode
We had hoped to let sendmail set this, but it doesn't look like
rails will allow that.