### PR TITLE
Fix grade push on Edge browser

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -9,7 +9,7 @@ class Api::SubmissionsController < Api::ApiApplicationController
       Integrations::SIS.post_grades_to_db(
         section_info[:section][:sis_course_id],
         section_info[:section][:sis_section_id],
-        params[:type],
+        params[:gradetype],
         grades(section_info),
       )
     end

--- a/client/apps/post_grades/actions/submissions.js
+++ b/client/apps/post_grades/actions/submissions.js
@@ -11,7 +11,7 @@ const requests = [
 
 export const Constants = wrapper(actions, requests);
 
-export const createStudentInfo = (sections, assignmentId, type) => ({
+export const createStudentInfo = (sections, assignmentId, gradeType) => ({
   type: Constants.CREATE_STUDENT_INFO,
   method: Network.POST,
   url: 'api/submissions/',
@@ -20,6 +20,6 @@ export const createStudentInfo = (sections, assignmentId, type) => ({
   },
   body: {
     sections,
-    type,
+    gradetype: gradeType,
   }
 });

--- a/client/apps/post_grades/components/post_grades/_post_grades.jsx
+++ b/client/apps/post_grades/components/post_grades/_post_grades.jsx
@@ -105,7 +105,7 @@ export class PostGradesTool extends React.Component {
 
     // Edge browser returns an HtmlCollection instead of the checked radio.
     // So we have to manually get the checked value.
-    const gradeType = document.querySelector('.post-grades-modal input[name="gradeType"]:checked');
+    const gradeType = e.target.querySelector('input[name="gradeType"]:checked');
 
     if (this.state.confirm) {
       let sections = [];

--- a/client/apps/post_grades/components/post_grades/_post_grades.jsx
+++ b/client/apps/post_grades/components/post_grades/_post_grades.jsx
@@ -101,8 +101,11 @@ export class PostGradesTool extends React.Component {
     const {
       gradeSection = {},
       gradeColumn = {},
-      gradeType = {},
     } = e.target.elements;
+
+    // Edge browser returns an HtmlCollection instead of the checked radio.
+    // So we have to manually get the checked value.
+    const gradeType = document.querySelector('.post-grades-modal input[name="gradeType"]:checked');
 
     if (this.state.confirm) {
       let sections = [];

--- a/client/apps/post_grades/components/post_grades/sections.jsx
+++ b/client/apps/post_grades/components/post_grades/sections.jsx
@@ -69,7 +69,6 @@ export default class Sections extends React.PureComponent {
         </div>
       );
     }
-    const singleSection = _.size(sections) === 1;
 
     return (
       <div className="input-container">
@@ -81,7 +80,7 @@ export default class Sections extends React.PureComponent {
           id="gradeSection"
           aria-describedby="date-posted"
         >
-          { singleSection ? null : <option value={-1}>All Sections</option> }
+          <option value="-1">All Sections</option>
           {
             _.map(sections, section => (
               <option

--- a/client/apps/post_grades/components/post_grades/sections.jsx
+++ b/client/apps/post_grades/components/post_grades/sections.jsx
@@ -69,6 +69,7 @@ export default class Sections extends React.PureComponent {
         </div>
       );
     }
+    const singleSection = _.size(sections) === 1;
 
     return (
       <div className="input-container">
@@ -80,7 +81,7 @@ export default class Sections extends React.PureComponent {
           id="gradeSection"
           aria-describedby="date-posted"
         >
-          <option value="-1">All Sections</option>
+          { singleSection ? null : <option value={-1}>All Sections</option> }
           {
             _.map(sections, section => (
               <option

--- a/spec/controllers/api/submissions_controller_spec.rb
+++ b/spec/controllers/api/submissions_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Api::SubmissionsController, type: :controller do
                   sis_course_id: nil,
                 },
               ],
-              type: generate(:gradetype),
+              gradetype: generate(:gradetype),
               assignment_id: "total",
             }
           end
@@ -90,7 +90,7 @@ RSpec.describe Api::SubmissionsController, type: :controller do
                   sis_course_id: nil,
                 },
               ],
-              type: generate(:gradetype),
+              gradetype: generate(:gradetype),
               assignment_id: "16753",
             }
           end


### PR DESCRIPTION
Get the gradetype using a document querySelector.
Change post to send gradetype instead of type for clarity.
Always display the All Sections and each section in the dropdown.
Update specs.