### PR TITLE
Fix post grades all sections

### DIFF
--- a/client/apps/post_grades/components/post_grades/sections.jsx
+++ b/client/apps/post_grades/components/post_grades/sections.jsx
@@ -69,7 +69,6 @@ export default class Sections extends React.PureComponent {
         </div>
       );
     }
-    const singleSection = _.size(sections) === 1;
 
     return (
       <div className="input-container">
@@ -81,7 +80,7 @@ export default class Sections extends React.PureComponent {
           id="gradeSection"
           aria-describedby="date-posted"
         >
-          { singleSection ? null : <option value={-1}>All Sections</option> }
+          <option value="-1">All Sections</option>
           {
             _.map(sections, section => (
               <option


### PR DESCRIPTION
Remove feature (#307) that only shows the one section if there is only one section.
We can add this back in later once the functionality can be fixed.