### PR TITLE
Display notice if User Enrollment cannot be ended

### DIFF
--- a/client/apps/course_completion/components/complete.jsx
+++ b/client/apps/course_completion/components/complete.jsx
@@ -51,6 +51,9 @@ export class Complete extends React.Component {
           this.setState({ msg: 'Already Completed' });
         }
       }
+      if (enrollment.type !== 'StudentEnrollment') {
+        this.setState({ msg: 'Cannot complete non-student enrollment' });
+      }
       // Couldn't find an enrollment in the course to end
       if (nextProps.enrollments === [] || enrollment === undefined) {
         this.setState({ msg: 'No enrollment to complete' });


### PR DESCRIPTION
This pull request changes the displayed text when placing the tool in the editor and when being viewed by an user enrollment not of the Student type.