### PR TITLE
Fix postgrades with more than 10 students

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -29,12 +29,16 @@ class Api::SubmissionsController < Api::ApiApplicationController
         section_subs = canvas_api.proxy(
           "LIST_ASSIGNMENT_SUBMISSIONS_SECTIONS",
           sub_params,
+          nil,
+          true,
         )
       end
 
       section_users = canvas_api.proxy(
         "LIST_ENROLLMENTS_SECTIONS",
         { section_id: section["id"] },
+        nil,
+        true,
       )
 
       {


### PR DESCRIPTION
Get all grades, not just first 10 students.
We will want to change this to get 100 at a time through a background job.