### PR TITLE
Fix SCORM to canvas file uploads

### DIFF
--- a/app/jobs/upload_canvas_job.rb
+++ b/app/jobs/upload_canvas_job.rb
@@ -67,7 +67,7 @@ class UploadCanvasJob < ApplicationJob
           name: File.basename(file_path),
           content_type: "application/zip",
           parent_folder_path: "scorm_files/",
-          on_duplicate: "rename",
+          on_duplicate: "overwrite",
         },
       ).parsed_response
       canvas_response["upload_params"]["file"] =


### PR DESCRIPTION
Rather than create duplicate files, just overwrite.
This fixes a problem where the background worker attempts multiple times to upload a file to canvas and fails. We don't want that scorm_files directory bloated with hundreds of partial uploads.