### PR TITLE
Fix scorm packages to not submit to LMS for teachers.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,6 +179,10 @@ class User < ApplicationRecord
     role?("administrator")
   end
 
+  def student_in_course?(context_id = nil)
+    role?("urn:lti:role:ims/lis/Learner", context_id)
+  end
+
   def can_edit?(user)
     return false if user.nil?
     id == user.id || user.admin?

--- a/db/migrate/20190214164316_add_context_id_to_registration.rb
+++ b/db/migrate/20190214164316_add_context_id_to_registration.rb
@@ -1,0 +1,13 @@
+class AddContextIdToRegistration < ActiveRecord::Migration[5.1]
+  def up
+    add_column :registrations, :context_id, :string
+    remove_index :registrations, [:lms_course_id, :lms_user_id]
+    add_index :registrations, [:lms_course_id, :lms_user_id, :context_id], name: "index_registrations_on_lms_course_id_lms_user_id_context_id"
+  end
+
+  def down
+    remove_index :registrations, [:lms_course_id, :lms_user_id, :context_id]
+    add_index :registrations, [:lms_course_id, :lms_user_id]
+    remove_column :registrations, :context_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180627170924) do
+ActiveRecord::Schema.define(version: 20190214164316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -234,8 +234,9 @@ ActiveRecord::Schema.define(version: 20180627170924) do
     t.text "encrypted_scorm_cloud_passback_secret_iv"
     t.text "encrypted_scorm_cloud_passback_secret"
     t.string "scorm_registration_id"
+    t.string "context_id"
     t.index ["application_instance_id"], name: "index_registrations_on_application_instance_id"
-    t.index ["lms_course_id", "lms_user_id"], name: "index_registrations_on_lms_course_id_and_lms_user_id"
+    t.index ["lms_course_id", "lms_user_id", "context_id"], name: "index_registrations_on_lms_course_id_lms_user_id_context_id"
     t.index ["lms_course_id"], name: "index_registrations_on_lms_course_id"
     t.index ["lms_user_id"], name: "index_registrations_on_lms_user_id"
     t.index ["scorm_registration_id"], name: "index_registrations_on_scorm_registration_id"

--- a/spec/controllers/scorm_courses_controller_spec.rb
+++ b/spec/controllers/scorm_courses_controller_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe ScormCoursesController, type: :controller do
         :registration,
         application_instance: @application_instance,
         scorm_course: scorm_course,
+        context_id: FactoryBot.generate(:context_id),
       )
       response = Object.new
       allow(response).to receive(:success?).and_return(true)
       allow_any_instance_of(AJIMS::LTI::ToolProvider).to receive(:post_replace_result!).and_return(response)
+      @student = FactoryBot.create(:user_canvas, lms_user_id: FactoryBot.generate(:lms_user_id))
     end
     it "should reject bad password" do
       params = {
@@ -49,6 +51,9 @@ RSpec.describe ScormCoursesController, type: :controller do
               <success>failed</success>
               <totaltime>19</totaltime>
               <score>0</score>
+              <learner>
+                <id>#{@student.lms_user_id}</id>
+              </learner>
           </registrationreport>",
         password: @reg.scorm_cloud_passback_secret,
       }

--- a/spec/factories/_common.rb
+++ b/spec/factories/_common.rb
@@ -115,6 +115,14 @@ FactoryBot.define do
     "meh789_#{n}"
   end
 
+  sequence :lms_user_id do |n|
+    n + 1024
+  end
+
+  sequence :context_id do |n|
+    "b43d050b8cd75d5c2734fbc117ab917882a16a9a#{n}"
+  end
+
   sequence :common_grade do
     ["100.0", "97.2", "95.8", "92.1", "90.6", "87.0", "85.1", "82.9", "80.3", "77.0", "75.8", "72.3", "67.2"].sample
   end

--- a/spec/services/scorm_cloud_service_spec.rb
+++ b/spec/services/scorm_cloud_service_spec.rb
@@ -38,7 +38,7 @@ describe "Scorm Cloud Service sync score", type: :controller do
     @application_instance.update_attributes(config: { "scorm_type" => "cloud" })
     scorm_course = create(:scorm_course)
     @user = create(:user, lms_user_id: 2)
-    @context_id = "123abc"
+    @context_id = generate(:context_id)
     @reg = Registration.create(
       lms_user_id: @user.lms_user_id,
       application_instance: @application_instance,

--- a/spec/services/scorm_cloud_service_spec.rb
+++ b/spec/services/scorm_cloud_service_spec.rb
@@ -37,19 +37,28 @@ describe "Scorm Cloud Service sync score", type: :controller do
     @application_instance = FactoryBot.create(:application_instance)
     @application_instance.update_attributes(config: { "scorm_type" => "cloud" })
     scorm_course = create(:scorm_course)
+    @user = create(:user, lms_user_id: 2)
+    @context_id = "123abc"
     @reg = Registration.create(
-      lms_user_id: 2,
+      lms_user_id: @user.lms_user_id,
       application_instance: @application_instance,
       lis_outcome_service_url: "http://cloud.scorm.com/this?isaspec",
       scorm_course: scorm_course,
+      context_id: @context_id,
     )
-    @registration = { "format" => "summary",
-                      "regid" => @reg.scorm_registration_id,
-                      "instanceid" => "0",
-                      "complete" => "complete",
-                      "success" => "failed",
-                      "totaltime" => "19",
-                      "score" => "0" }
+    @user.add_to_role("urn:lti:role:ims/lis/Learner", @context_id)
+    @registration = {
+      "format" => "summary",
+      "regid" => @reg.scorm_registration_id,
+      "instanceid" => "0",
+      "complete" => "complete",
+      "success" => "failed",
+      "totaltime" => "19",
+      "score" => "0",
+      "learner" => {
+        "id" => @user.lms_user_id,
+      },
+    }
   end
 
   it "should sync the registration score" do

--- a/spec/services/scorm_engine_service_spec.rb
+++ b/spec/services/scorm_engine_service_spec.rb
@@ -123,19 +123,28 @@ describe "Scorm Engine Service sync score", type: :controller do
     @application_instance.update_attributes(config: { "scorm_type" => "engine" })
     @lms_course_id = "1234"
     @scorm_course = create(:scorm_course, scorm_service_id: "3_#{@lms_course_id}")
+    @user = create(:user, lms_user_id: 2)
+    @context_id = "123abc"
     @reg = Registration.create(
-      lms_user_id: 2,
+      lms_user_id: @user.lms_user_id,
       application_instance: @application_instance,
       lis_outcome_service_url: Rails.application.secrets.scorm_url,
       lms_course_id: @scorm_course.scorm_service_id,
+      context_id: @context_id,
     )
-    @registration = { "format" => "summary",
-                      "regid" => @reg.scorm_registration_id.to_s,
-                      "instanceid" => "0",
-                      "complete" => "complete",
-                      "success" => "failed",
-                      "totaltime" => "19",
-                      "score" => "0" }
+    @user.add_to_role("urn:lti:role:ims/lis/Learner", @context_id)
+    @registration = {
+      "format" => "summary",
+      "regid" => @reg.scorm_registration_id.to_s,
+      "instanceid" => "0",
+      "complete" => "complete",
+      "success" => "failed",
+      "totaltime" => "19",
+      "score" => "0",
+      "learner" => {
+        "id" => @user.lms_user_id,
+      },
+    }
   end
 
   it "should sync the registration score" do

--- a/spec/services/scorm_engine_service_spec.rb
+++ b/spec/services/scorm_engine_service_spec.rb
@@ -124,7 +124,7 @@ describe "Scorm Engine Service sync score", type: :controller do
     @lms_course_id = "1234"
     @scorm_course = create(:scorm_course, scorm_service_id: "3_#{@lms_course_id}")
     @user = create(:user, lms_user_id: 2)
-    @context_id = "123abc"
+    @context_id = generate(:context_id)
     @reg = Registration.create(
       lms_user_id: @user.lms_user_id,
       application_instance: @application_instance,


### PR DESCRIPTION
Only submit for students

This is backwards compatible with data (Registrations) created prior to this change. If a student launches a SCORM course and there isn't a context_id associated with their registration, it will then be associated. This context_id is used to determine if the user is a student in the course and only submit to the LMS if they are a student.