### PR TITLE
Fix polling for scorm status

### DIFF
--- a/client/apps/scorm/reducers/scorm.js
+++ b/client/apps/scorm/reducers/scorm.js
@@ -83,9 +83,16 @@ export default (state = initialState, action) => {
     case PackageConstants.POLL_STATUS_DONE: {
       const {
         status,
-        scorm_course_id:scormCourseId,
         message,
       } = action.payload;
+
+      let {
+        scorm_course_id:scormCourseId,
+      } = action.payload;
+
+      if (!scormCourseId) {
+        scormCourseId = state.scormCourseId;
+      }
 
       const shouldPollStatus = !_.includes(['COMPLETE', 'FAILED'], status);
       let shouldRefreshList = !shouldPollStatus;


### PR DESCRIPTION
This fixes a case where if the browser looses it's internet connection, then it would start polling for the status of id `undefined`.