### PR TITLE
Handle Net::ReadTimeout from canvas

### DIFF
--- a/app/jobs/upload_canvas_job.rb
+++ b/app/jobs/upload_canvas_job.rb
@@ -66,6 +66,8 @@ class UploadCanvasJob < ApplicationJob
     rescue LMS::Canvas::InvalidAPIRequestFailedException => e
       # ignore it, nobody cares if it is a gateway timeout
       raise e if e.status != 504
+    rescue Net::ReadTimeout
+      # ignore it, nobody cares
     end
     file_id = upload_canvas_file(
       lms_course_id,

--- a/app/jobs/wrapup_upload_canvas_job.rb
+++ b/app/jobs/wrapup_upload_canvas_job.rb
@@ -24,6 +24,8 @@ class WrapupUploadCanvasJob < ApplicationJob
     rescue LMS::Canvas::InvalidAPIRequestFailedException => e
       # ignore it, nobody cares if it is a gateway timeout
       raise e if e.status != 504
+    rescue Net::ReadTimeout
+      # ignore it, nobody cares
     end
 
     if scorm_course.lms_assignment_id.present?


### PR DESCRIPTION
If we get a read timeout while deleting or hiding a file, just ignore it.