### PR TITLE
Update Seeds to Allow a Custom Subdomain for the User Tool

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -421,7 +421,7 @@ applications = [
       lti_key: Application::USERTOOL,
       site_url: secrets.canvas_url,
       canvas_token: secrets.canvas_token,
-      domain: "#{Application::USERTOOL}.#{secrets.application_root_domain}",
+      domain: "#{secrets.user_tool_subdomain || Application::USERTOOL}.#{secrets.application_root_domain}",
     }],
   },
 ]


### PR DESCRIPTION
## Goal

Pivotal Tracker: [#171580747](https://www.pivotaltracker.com/story/show/171580747)

We need to allow the user tool subdomain to be configurable so we can use our custom subdomain in production.

We still want the subdomain to default to `usertool` if a custom one isn't specified.

## Needed Supporting Changes
We need to add the custom subdomain to the cluster setup as described in [Pivotal Tracker #171579729](https://www.pivotaltracker.com/story/show/171579729).