### PR TITLE
Improve Subdomain Check

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -421,7 +421,7 @@ applications = [
       lti_key: Application::USERTOOL,
       site_url: secrets.canvas_url,
       canvas_token: secrets.canvas_token,
-      domain: "#{secrets.user_tool_subdomain || Application::USERTOOL}.#{secrets.application_root_domain}",
+      domain: "#{secrets.user_tool_subdomain.presence || Application::USERTOOL}.#{secrets.application_root_domain}",
     }],
   },
 ]


### PR DESCRIPTION
By adding `presence`, we'll only use the value in `secrets.user_tool_subdomain` if it is present. This will avoid using an empty string which someone might conceivably set `user_tool_subdomain` to.

``` ruby
nil.presence || Application::USERTOOL
=> "usertool"

" ".presence || Application::USERTOOL
=> "usertool"

"123".presence || Application::USERTOOL
=> "123"
```  