### PR TITLE
Add Search Page

### DIFF
--- a/app/controllers/api/canvas_users_controller.rb
+++ b/app/controllers/api/canvas_users_controller.rb
@@ -1,0 +1,12 @@
+class Api::CanvasUsersController < ApplicationController
+  include Concerns::CanvasSupport
+
+  def index
+    canvas_response = canvas_api.proxy(
+      "LIST_USERS_IN_ACCOUNT",
+      { account_id: params[:canvas_account_id], search_term: params[:search_term] },
+    )
+
+    render json: canvas_response.parsed_response, status: :ok
+  end
+end

--- a/app/controllers/api/canvas_users_controller.rb
+++ b/app/controllers/api/canvas_users_controller.rb
@@ -1,5 +1,7 @@
-class Api::CanvasUsersController < ApplicationController
+class Api::CanvasUsersController < Api::ApiApplicationController
   include Concerns::CanvasSupport
+
+  before_action :validate_token
 
   def index
     canvas_response = canvas_api.proxy(

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -1,9 +1,20 @@
 import wrapper from 'atomic-fuel/libs/constants/wrapper';
+import Network from 'atomic-fuel/libs/constants/network';
 
 // Local actions
 const actions = [];
 
 // Actions that make an api request
-const requests = [];
+const requests = ['SEARCH_FOR_ACCOUNT_USERS'];
 
-export default wrapper(actions, requests);
+export const Constants = wrapper(actions, requests);
+
+export const searchForAccountUsers = (lmsAccountId, searchTerm) => ({
+  type: Constants.SEARCH_FOR_ACCOUNT_USERS,
+  method: Network.GET,
+  url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
+  params: {
+    search_term: searchTerm,
+    include_sub_accounts: true,
+  },
+});

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -1,0 +1,39 @@
+import { searchForAccountUsers } from './application';
+
+describe('application actions', () => {
+  describe('searchForAccountUsers', () => {
+    it('generates the correct action', () => {
+      const lmsAccountId = 123;
+      const searchTerm = 'student name';
+      const expectedAction = {
+        type: 'SEARCH_FOR_ACCOUNT_USERS',
+        method: 'get',
+        url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
+        params: {
+          search_term: searchTerm,
+          include_sub_accounts: true,
+        },
+      };
+
+      expect(searchForAccountUsers(lmsAccountId, searchTerm)).toEqual(expectedAction);
+    });
+
+    describe('when no search term is given', () => {
+      it('generates the correct action', () => {
+        const lmsAccountId = 123;
+        const searchTerm = '';
+        const expectedAction = {
+          type: 'SEARCH_FOR_ACCOUNT_USERS',
+          method: 'get',
+          url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
+          params: {
+            search_term: searchTerm,
+            include_sub_accounts: true,
+          },
+        };
+
+        expect(searchForAccountUsers(lmsAccountId, searchTerm)).toEqual(expectedAction);
+      });
+    });
+  });
+});

--- a/client/apps/user_tool/components/home.jsx
+++ b/client/apps/user_tool/components/home.jsx
@@ -2,14 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Auth from 'atomic-canvas/libs/components/canvas_authentication';
+import SearchPage from './main/search_page';
 
 const select = state => ({
   canvasAuthRequired: state.settings.canvas_auth_required,
 });
 
-const Home = props => (
+const Home = ({ canvasAuthRequired }) => (
   <div>
-    { props.canvasAuthRequired ? <Auth autoSubmit hideButton /> : <p>User Tool app</p> }
+    { canvasAuthRequired ? <Auth autoSubmit hideButton /> : <SearchPage /> }
   </div>
 );
 

--- a/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchPage renders the search page 1`] = `
+<div>
+  <form>
+    <input
+      onChange={[Function]}
+      placeholder="Search for students..."
+      type="search"
+      value=""
+    />
+    <button
+      onClick={[Function]}
+      type="submit"
+    >
+      Search
+    </button>
+  </form>
+  <p>
+    Search Results:
+  </p>
+  <table>
+    <thead>
+      <tr>
+        <th
+          scope="col"
+        >
+          Name
+        </th>
+        <th
+          scope="col"
+        >
+          Email Address
+        </th>
+        <th
+          scope="col"
+        >
+          Roles
+        </th>
+        <th
+          scope="col"
+        >
+          Login ID
+        </th>
+        <th
+          scope="col"
+        >
+          SIS ID
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <UserSearchResult
+        key="1"
+        user={
+          Object {
+            "email": "countryfather@revolution.com",
+            "id": 1,
+            "login_id": "countryfather@revolution.com",
+            "roles": Array [
+              "admin",
+              "teacher",
+            ],
+            "sis_user_id": "george_123",
+            "sortable_name": "Washington, George",
+          }
+        }
+      />
+      <UserSearchResult
+        key="2"
+        user={
+          Object {
+            "email": "idodeclare@revolution.com",
+            "id": 2,
+            "login_id": "idodeclare@revolution.com",
+            "roles": Array [
+              "teacher",
+            ],
+            "sis_user_id": "thomas_123",
+            "sortable_name": "Jefferson, Thomas",
+          }
+        }
+      />
+    </tbody>
+  </table>
+</div>
+`;

--- a/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserSearchResult renders the user as a search result 1`] = `
+<tr>
+  <td>
+    Washington, George
+  </td>
+  <td>
+    countryfather@revolution.com
+  </td>
+  <td>
+    admin
+    teacher
+  </td>
+  <td>
+    countryfather@revolution.com
+  </td>
+  <td>
+    george_123
+  </td>
+</tr>
+`;

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { searchForAccountUsers } from '../../actions/application';
+import UserSearchResult from './user_search_result';
+
+const select = state => ({
+  matchingUsers: state.application.matchingUsers,
+  lmsAccountId: state.settings.custom_canvas_account_id,
+});
+
+export class SearchPage extends React.Component {
+  static propTypes = {
+    searchForAccountUsers: PropTypes.func.isRequired,
+    matchingUsers: PropTypes.array.isRequired,
+    lmsAccountId: PropTypes.string.isRequired,
+  };
+
+  constructor() {
+    super();
+
+    this.state = { searchTerm: '' };
+
+    this.updateSearchTerm = this.updateSearchTerm.bind(this);
+  }
+
+  updateSearchTerm(event) {
+    this.setState({ searchTerm: event.target.value });
+  }
+
+  render() {
+    const { searchForAccountUsers:search, matchingUsers, lmsAccountId } = this.props;
+    const { searchTerm } = this.state;
+    const renderedUsers = matchingUsers.map(user => (
+      <UserSearchResult key={user.id} user={user} />
+    ));
+
+    return (
+      <div>
+        <form>
+          <input type="search" value={searchTerm} onChange={this.updateSearchTerm} placeholder="Search for students..." />
+          <button type="submit" onClick={() => search(lmsAccountId, searchTerm)}>Search</button>
+        </form>
+        <p>Search Results:</p>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Email Address</th>
+              <th scope="col">Roles</th>
+              <th scope="col">Login ID</th>
+              <th scope="col">SIS ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {renderedUsers}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+export default connect(select, { searchForAccountUsers })(SearchPage);

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { SearchPage } from './search_page';
+
+describe('SearchPage', () => {
+  const props = {
+    searchForAccountUsers: () => {},
+    matchingUsers: [
+      {
+        id: 1,
+        sortable_name: 'Washington, George',
+        email: 'countryfather@revolution.com',
+        roles: ['admin', 'teacher'],
+        login_id: 'countryfather@revolution.com',
+        sis_user_id: 'george_123',
+      },
+      {
+        id: 2,
+        sortable_name: 'Jefferson, Thomas',
+        email: 'idodeclare@revolution.com',
+        roles: ['teacher'],
+        login_id: 'idodeclare@revolution.com',
+        sis_user_id: 'thomas_123',
+      }
+    ],
+    lmsAccountId: '1',
+  };
+
+  it('renders the search page', () => {
+    const result = shallow(<SearchPage
+      matchingUsers={props.matchingUsers}
+      searchForAccountUsers={props.searchForAccountUsers}
+      lmsAccountId={props.lmsAccountId}
+    />);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  describe('when the user submits a search', () => {
+    it('submits a search request', () => {
+      spyOn(props, 'searchForAccountUsers');
+      const searchTerm = 'student name';
+      const result = shallow(<SearchPage
+        matchingUsers={props.matchingUsers}
+        searchForAccountUsers={props.searchForAccountUsers}
+        lmsAccountId={props.lmsAccountId}
+      />);
+
+      result.find('input').simulate('change', { target: { value: searchTerm } });
+      result.find('button[type="submit"]').simulate('click');
+
+      expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+        props.lmsAccountId,
+        searchTerm,
+      );
+    });
+  });
+});

--- a/client/apps/user_tool/components/main/user_search_result.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class UserSearchResult extends React.Component {
+  static propTypes = {
+    user: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { user } = this.props;
+
+    return (
+      <tr>
+        <td>{user.sortable_name}</td>
+        <td>{user.email}</td>
+        <td>{user.roles}</td>
+        <td>{user.login_id}</td>
+        <td>{user.sis_user_id}</td>
+      </tr>
+    );
+  }
+}

--- a/client/apps/user_tool/components/main/user_search_result.spec.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.spec.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import UserSearchResult from './user_search_result';
+
+describe('UserSearchResult', () => {
+  const user = {
+    sortable_name: 'Washington, George',
+    email: 'countryfather@revolution.com',
+    roles: ['admin', 'teacher'],
+    login_id: 'countryfather@revolution.com',
+    sis_user_id: 'george_123',
+  };
+
+  it('renders the user as a search result', () => {
+    const result = shallow(<UserSearchResult user={user} />);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -1,7 +1,16 @@
-const initialState = () => ({});
+import { Constants as ApplicationConstants } from '../actions/application';
+
+const initialState = () => ({ matchingUsers: [] });
 
 export default (state = initialState(), action) => {
   switch (action.type) {
+
+    case ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE: {
+      const matchingUsers = action.payload;
+
+      return { ...state, ...{ matchingUsers } };
+    }
+
     default:
       return state;
   }

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -1,11 +1,46 @@
-import application from './application';
+import applicationReducer from './application';
+import { Constants as ApplicationConstants } from '../actions/application';
 
 describe('application reducer', () => {
+  let initialState = () => ({ matchingUsers: [] });
+
   describe('initial state', () => {
     it('returns empty state', () => {
-      const initialState = {};
-      const state = application(initialState, {});
-      expect(state).toEqual({});
+      const state = applicationReducer(initialState, {});
+
+      expect(state).toEqual(initialState);
+    });
+  });
+
+  describe('SEARCH_FOR_ACCOUNT_USERS_DONE', () => {
+    it('updates matchingUsers with the response payload', () => {
+      const matchingUsers = [
+        { id: 1, name: 'Student 1' },
+        { id: 2, name: 'Student 2' },
+        { id: 3, name: 'Student 3' },
+      ];
+      const action = {
+        type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
+        payload: matchingUsers,
+      };
+
+      const state = applicationReducer(initialState, action);
+
+      expect(state.matchingUsers).toEqual(matchingUsers);
+    });
+
+    describe('if there are no matching users', () => {
+      it('updates matchingUsers to an empty list', () => {
+        initialState = () => ({ matchingUsers: [{ id: 1, name: 'Student 1' }] });
+        const action = {
+          type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
+          payload: [],
+        };
+
+        const state = applicationReducer(initialState, action);
+
+        expect(state.matchingUsers).toEqual([]);
+      });
     });
   });
 });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,9 @@ Rails.application.routes.draw do
     resources :proctored_exams, only: [:update]
     post "proctor_conversations" => "proctor_conversations#initiate_conversation"
     resources :jwts
-    resources :canvas_accounts
+    resources :canvas_accounts do
+      resources :canvas_users, only: [:index]
+    end
     resources :oauths
     resources :courses, only: [] do
       resources :students, only: [:index]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -409,7 +409,6 @@ applications = [
       privacy_level: "public",
       icon: "oauth_icon.png",
       custom_fields: {
-        canvas_course_id: "$Canvas.course.id",
         external_tool_url: "$Canvas.externalTool.url",
       },
       account_navigation: {


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171524287](https://www.pivotaltracker.com/story/show/171524287), [#171524862](https://www.pivotaltracker.com/story/show/171524862), [#171524339](https://www.pivotaltracker.com/story/show/171524339)

This adds an initial, rudimentary search page. It allows you to search for a student and displays the 
 first page of results. It's missing things such as the ability to page through other results and displaying all of the necessary user information.

I'd written enough code that I wanted to get it reviewed before going farther.

## Demo
[Search Page](https://pull-request-demo-files.s3-us-west-2.amazonaws.com/search_page.mp4)