### PR TITLE
Update Menu Title from "Manage Users" to "User Management"

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -413,7 +413,7 @@ applications = [
         external_tool_url: "$Canvas.externalTool.url",
       },
       account_navigation: {
-        text: "Manage Users",
+        text: "User Management",
         visibility: "admins",
       },
     },


### PR DESCRIPTION
Pivotal Tracker: [#171727406](https://www.pivotaltracker.com/story/show/171727406)

All of the other items in the Canvas nav are nouns, so we want to mirror that.

![image](https://user-images.githubusercontent.com/6520489/76794885-a258ce00-678d-11ea-911e-cde318ec5f53.png)