### PR TITLE
Add Search Length Constraint

### DIFF
--- a/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
@@ -4,6 +4,7 @@ exports[`SearchPage renders the search page 1`] = `
 <div>
   <form>
     <input
+      minLength={3}
       onChange={[Function]}
       placeholder="Search for students..."
       type="search"

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -21,7 +21,6 @@ export class SearchPage extends React.Component {
 
     this.state = { searchTerm: '' };
     this.minSearchTermLength = 3;
-    this.updateSearchTerm = this.updateSearchTerm.bind(this);
   }
 
   updateSearchTerm(event) {
@@ -51,7 +50,7 @@ export class SearchPage extends React.Component {
             type="search"
             minLength={this.minSearchTermLength}
             value={searchTerm}
-            onChange={this.updateSearchTerm}
+            onChange={event => this.updateSearchTerm(event)}
             placeholder="Search for students..."
           />
           <button type="submit" onClick={() => this.handleSearch()}>Search</button>

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -20,7 +20,7 @@ export class SearchPage extends React.Component {
     super();
 
     this.state = { searchTerm: '' };
-
+    this.minSearchTermLength = 3;
     this.updateSearchTerm = this.updateSearchTerm.bind(this);
   }
 
@@ -28,8 +28,17 @@ export class SearchPage extends React.Component {
     this.setState({ searchTerm: event.target.value });
   }
 
+  handleSearch() {
+    const { lmsAccountId, searchForAccountUsers:search } = this.props;
+    const { searchTerm } = this.state;
+
+    if (searchTerm.length >= this.minSearchTermLength) {
+      search(lmsAccountId, searchTerm);
+    }
+  }
+
   render() {
-    const { searchForAccountUsers:search, matchingUsers, lmsAccountId } = this.props;
+    const { matchingUsers } = this.props;
     const { searchTerm } = this.state;
     const renderedUsers = matchingUsers.map(user => (
       <UserSearchResult key={user.id} user={user} />
@@ -38,8 +47,14 @@ export class SearchPage extends React.Component {
     return (
       <div>
         <form>
-          <input type="search" value={searchTerm} onChange={this.updateSearchTerm} placeholder="Search for students..." />
-          <button type="submit" onClick={() => search(lmsAccountId, searchTerm)}>Search</button>
+          <input
+            type="search"
+            minLength={this.minSearchTermLength}
+            value={searchTerm}
+            onChange={this.updateSearchTerm}
+            placeholder="Search for students..."
+          />
+          <button type="submit" onClick={() => this.handleSearch()}>Search</button>
         </form>
         <p>Search Results:</p>
         <table>

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -55,5 +55,25 @@ describe('SearchPage', () => {
         searchTerm,
       );
     });
+
+    describe('when the user submits a search with less than 3 characters', () => {
+      it('does not submit the search', () => {
+        spyOn(props, 'searchForAccountUsers');
+        const searchTerm = 'jo';
+        const result = shallow(<SearchPage
+          matchingUsers={props.matchingUsers}
+          searchForAccountUsers={props.searchForAccountUsers}
+          lmsAccountId={props.lmsAccountId}
+        />);
+
+        result.find('input').simulate('change', { target: { value: searchTerm } });
+        result.find('button[type="submit"]').simulate('click');
+
+        expect(props.searchForAccountUsers).not.toHaveBeenCalledWith(
+          props.lmsAccountId,
+          searchTerm,
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171864889](https://www.pivotaltracker.com/story/show/171864889)

The [Canvas API endpoint](https://canvas.instructure.com/doc/api/users.html#method.users.api_index) we're using to search requires that the `search_term` parameter be at least 3 characters. It returns a `400 Bad Request` if you send less than 3.

This branch enforces that constraint on the front-end.

## Demo
[Search Term Length Constraint](https://pull-request-demo-files.s3-us-west-2.amazonaws.com/search_term_length_constraint.mp4)