### PR TITLE
Prevent Form Submission When Clicking the "Search" Button

### DIFF
--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -27,7 +27,10 @@ export class SearchPage extends React.Component {
     this.setState({ searchTerm: event.target.value });
   }
 
-  handleSearch() {
+  handleSearch(event) {
+    event.preventDefault();
+    event.target.form.reportValidity();
+
     const { lmsAccountId, searchForAccountUsers:search } = this.props;
     const { searchTerm } = this.state;
 
@@ -53,7 +56,7 @@ export class SearchPage extends React.Component {
             onChange={event => this.updateSearchTerm(event)}
             placeholder="Search for students..."
           />
-          <button type="submit" onClick={() => this.handleSearch()}>Search</button>
+          <button type="submit" onClick={event => this.handleSearch(event)}>Search</button>
         </form>
         <p>Search Results:</p>
         <table>

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import { SearchPage } from './search_page';
 
@@ -41,7 +41,7 @@ describe('SearchPage', () => {
     it('submits a search request', () => {
       spyOn(props, 'searchForAccountUsers');
       const searchTerm = 'student name';
-      const result = shallow(<SearchPage
+      const result = mount(<SearchPage
         matchingUsers={props.matchingUsers}
         searchForAccountUsers={props.searchForAccountUsers}
         lmsAccountId={props.lmsAccountId}
@@ -60,7 +60,7 @@ describe('SearchPage', () => {
       it('does not submit the search', () => {
         spyOn(props, 'searchForAccountUsers');
         const searchTerm = 'jo';
-        const result = shallow(<SearchPage
+        const result = mount(<SearchPage
           matchingUsers={props.matchingUsers}
           searchForAccountUsers={props.searchForAccountUsers}
           lmsAccountId={props.lmsAccountId}


### PR DESCRIPTION
## Goal
In Firefox, things work fine without calling `event.preventDefault()`. In Chrome, Safari and Edge though, clicking the "Search" button submits an invalid "GET" request to the server which returns a 401 Unauthorized and the application crashes.

Adding `event.preventDefault()` prevents that invalid request. Adding `event.target.form.reportValidity()` triggers the native browser form validation which lets the user know if their search term is valid or not. Before adding `event.preventDefault()` the form validation happened automatically. Now, we have to call it explicitly.

## Tradeoffs & Alternatives
I'm not a fan of calling `event.preventDefault()` when I can avoid it, but I don't know of a better solution here.

## Demo
**Before**
![form_submission_issue_before](https://user-images.githubusercontent.com/6520489/77095688-dde4d980-69d3-11ea-9671-c84b1ce7038e.gif)

**After**
![form_submission_issue_after](https://user-images.githubusercontent.com/6520489/77095713-e5a47e00-69d3-11ea-85ce-d838ec6d3995.gif)