### PR TITLE
Add Pagination for Search Results

### DIFF
--- a/app/controllers/api/canvas_users_controller.rb
+++ b/app/controllers/api/canvas_users_controller.rb
@@ -6,9 +6,20 @@ class Api::CanvasUsersController < Api::ApiApplicationController
   def index
     canvas_response = canvas_api.proxy(
       "LIST_USERS_IN_ACCOUNT",
-      { account_id: params[:canvas_account_id], search_term: params[:search_term] },
+      {
+        account_id: params[:canvas_account_id],
+        search_term: params[:search_term],
+        page: params[:page],
+      },
     )
 
-    render json: canvas_response.parsed_response, status: :ok
+    render(
+      json: {
+        matching_users: canvas_response.parsed_response,
+        previous_page: previous_page_number(canvas_response),
+        next_page: next_page_number(canvas_response)
+      },
+      status: :ok,
+    )
   end
 end

--- a/app/controllers/api/canvas_users_controller.rb
+++ b/app/controllers/api/canvas_users_controller.rb
@@ -16,8 +16,8 @@ class Api::CanvasUsersController < Api::ApiApplicationController
     render(
       json: {
         matching_users: canvas_response.parsed_response,
-        previous_page: previous_page_number(canvas_response),
-        next_page: next_page_number(canvas_response)
+        previous_page_available: previous_page_available?(canvas_response),
+        next_page_available: next_page_available?(canvas_response),
       },
       status: :ok,
     )

--- a/app/controllers/concerns/canvas_support.rb
+++ b/app/controllers/concerns/canvas_support.rb
@@ -43,5 +43,22 @@ module Concerns
       # Add custom logic to protect specific api calls
       true
     end
+
+    def previous_page_number(canvas_response)
+      page_number_from_link_header(canvas_response, "prev")
+    end
+
+    def next_page_number(canvas_response)
+      page_number_from_link_header(canvas_response, "next")
+    end
+
+    def page_number_from_link_header(canvas_response, rel)
+      links = canvas_response.headers["Link"].split(",")
+      matching_link = links.find { |link| link.match?(/rel=['"]#{rel}['"]/) }
+
+      return unless matching_link
+
+      matching_link.match(/page=(\d+)/)[1]
+    end
   end
 end

--- a/app/controllers/concerns/canvas_support.rb
+++ b/app/controllers/concerns/canvas_support.rb
@@ -44,21 +44,12 @@ module Concerns
       true
     end
 
-    def previous_page_number(canvas_response)
-      page_number_from_link_header(canvas_response, "prev")
+    def previous_page_available?(canvas_response)
+      canvas_response.headers["link"].match?(/rel=['"]prev['"]/)
     end
 
-    def next_page_number(canvas_response)
-      page_number_from_link_header(canvas_response, "next")
-    end
-
-    def page_number_from_link_header(canvas_response, rel)
-      links = canvas_response.headers["Link"].split(",")
-      matching_link = links.find { |link| link.match?(/rel=['"]#{rel}['"]/) }
-
-      return unless matching_link
-
-      matching_link.match(/page=(\d+)/)[1]
+    def next_page_available?(canvas_response)
+      canvas_response.headers["link"].match?(/rel=['"]next['"]/)
     end
   end
 end

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -9,12 +9,13 @@ const requests = ['SEARCH_FOR_ACCOUNT_USERS'];
 
 export const Constants = wrapper(actions, requests);
 
-export const searchForAccountUsers = (lmsAccountId, searchTerm) => ({
+export const searchForAccountUsers = (lmsAccountId, searchTerm, page) => ({
   type: Constants.SEARCH_FOR_ACCOUNT_USERS,
   method: Network.GET,
   url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
   params: {
     search_term: searchTerm,
+    page,
     include_sub_accounts: true,
   },
 });

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -5,34 +5,38 @@ describe('application actions', () => {
     it('generates the correct action', () => {
       const lmsAccountId = 123;
       const searchTerm = 'student name';
+      const page = '2';
       const expectedAction = {
         type: 'SEARCH_FOR_ACCOUNT_USERS',
         method: 'get',
         url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
         params: {
           search_term: searchTerm,
+          page,
           include_sub_accounts: true,
         },
       };
 
-      expect(searchForAccountUsers(lmsAccountId, searchTerm)).toEqual(expectedAction);
+      expect(searchForAccountUsers(lmsAccountId, searchTerm, page)).toEqual(expectedAction);
     });
 
     describe('when no search term is given', () => {
       it('generates the correct action', () => {
         const lmsAccountId = 123;
         const searchTerm = '';
+        const page = '2';
         const expectedAction = {
           type: 'SEARCH_FOR_ACCOUNT_USERS',
           method: 'get',
           url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
           params: {
             search_term: searchTerm,
+            page,
             include_sub_accounts: true,
           },
         };
 
-        expect(searchForAccountUsers(lmsAccountId, searchTerm)).toEqual(expectedAction);
+        expect(searchForAccountUsers(lmsAccountId, searchTerm, page)).toEqual(expectedAction);
       });
     });
   });

--- a/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
@@ -84,18 +84,11 @@ exports[`SearchPage renders the search page 1`] = `
       />
     </tbody>
   </table>
-  <a
-    href="#"
-    onClick={[Function]}
-  >
-    Previous
-  </a>
-  ...
-  <a
-    href="#"
-    onClick={[Function]}
-  >
-    Next
-  </a>
+  <Pagination
+    changePageTo={[Function]}
+    currentPage={2}
+    nextPageAvailable={true}
+    previousPageAvailable={true}
+  />
 </div>
 `;

--- a/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
@@ -84,5 +84,18 @@ exports[`SearchPage renders the search page 1`] = `
       />
     </tbody>
   </table>
+  <a
+    href="#"
+    onClick={[Function]}
+  >
+    Previous
+  </a>
+  ...
+  <a
+    href="#"
+    onClick={[Function]}
+  >
+    Next
+  </a>
 </div>
 `;

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -7,6 +7,8 @@ import UserSearchResult from './user_search_result';
 const select = state => ({
   matchingUsers: state.application.matchingUsers,
   lmsAccountId: state.settings.custom_canvas_account_id,
+  previousPage: state.application.previousPage,
+  nextPage: state.application.nextPage,
 });
 
 export class SearchPage extends React.Component {
@@ -14,6 +16,8 @@ export class SearchPage extends React.Component {
     searchForAccountUsers: PropTypes.func.isRequired,
     matchingUsers: PropTypes.array.isRequired,
     lmsAccountId: PropTypes.string.isRequired,
+    previousPage: PropTypes.string,
+    nextPage: PropTypes.string,
   };
 
   constructor() {
@@ -37,7 +41,13 @@ export class SearchPage extends React.Component {
   }
 
   render() {
-    const { matchingUsers } = this.props;
+    const {
+      searchForAccountUsers:search,
+      lmsAccountId,
+      matchingUsers,
+      previousPage,
+      nextPage
+    } = this.props;
     const { searchTerm } = this.state;
     const renderedUsers = matchingUsers.map(user => (
       <UserSearchResult key={user.id} user={user} />
@@ -70,6 +80,9 @@ export class SearchPage extends React.Component {
             {renderedUsers}
           </tbody>
         </table>
+        <a href="#" onClick={() => search(lmsAccountId, searchTerm, previousPage)}>Previous</a>
+        ...
+        <a href="#" onClick={() => search(lmsAccountId, searchTerm, nextPage)}>Next</a>
       </div>
     );
   }

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -26,20 +26,25 @@ export class SearchPage extends React.Component {
   constructor() {
     super();
 
-    this.state = { searchTerm: '' };
+    this.state = {
+      inputSearchTerm: '', // The search term currently in the input field.
+      resultsSearchTerm: '', // The search term associated with the currently displayed results.
+    };
     this.minSearchTermLength = 3;
   }
 
-  updateSearchTerm(event) {
-    this.setState({ searchTerm: event.target.value });
+  updateInputSearchTerm(event) {
+    this.setState({ inputSearchTerm: event.target.value });
   }
 
   handleSearch() {
     const { lmsAccountId, searchForAccountUsers:search } = this.props;
-    const { searchTerm } = this.state;
+    const { inputSearchTerm } = this.state;
 
-    if (searchTerm.length >= this.minSearchTermLength) {
-      search(lmsAccountId, searchTerm);
+    this.setState({ resultsSearchTerm: inputSearchTerm });
+
+    if (inputSearchTerm.length >= this.minSearchTermLength) {
+      search(lmsAccountId, inputSearchTerm);
     }
   }
 
@@ -52,7 +57,7 @@ export class SearchPage extends React.Component {
       previousPageAvailable,
       nextPageAvailable
     } = this.props;
-    const { searchTerm } = this.state;
+    const { inputSearchTerm, resultsSearchTerm } = this.state;
     const renderedUsers = matchingUsers.map(user => (
       <UserSearchResult key={user.id} user={user} />
     ));
@@ -63,8 +68,8 @@ export class SearchPage extends React.Component {
           <input
             type="search"
             minLength={this.minSearchTermLength}
-            value={searchTerm}
-            onChange={event => this.updateSearchTerm(event)}
+            value={inputSearchTerm}
+            onChange={event => this.updateInputSearchTerm(event)}
             placeholder="Search for students..."
           />
           <button type="submit" onClick={() => this.handleSearch()}>Search</button>
@@ -85,7 +90,7 @@ export class SearchPage extends React.Component {
           </tbody>
         </table>
         <Pagination
-          changePageTo={page => search(lmsAccountId, searchTerm, page)}
+          changePageTo={page => search(lmsAccountId, resultsSearchTerm, page)}
           currentPage={currentPage}
           previousPageAvailable={previousPageAvailable}
           nextPageAvailable={nextPageAvailable}

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { searchForAccountUsers } from '../../actions/application';
 import UserSearchResult from './user_search_result';
+import Pagination from '../../../../common/components/common/pagination';
 
 const select = state => ({
   matchingUsers: state.application.matchingUsers,
   lmsAccountId: state.settings.custom_canvas_account_id,
-  previousPage: state.application.previousPage,
-  nextPage: state.application.nextPage,
+  currentPage: state.application.currentPage,
+  previousPageAvailable: state.application.previousPageAvailable,
+  nextPageAvailable: state.application.nextPageAvailable,
 });
 
 export class SearchPage extends React.Component {
@@ -16,8 +18,9 @@ export class SearchPage extends React.Component {
     searchForAccountUsers: PropTypes.func.isRequired,
     matchingUsers: PropTypes.array.isRequired,
     lmsAccountId: PropTypes.string.isRequired,
-    previousPage: PropTypes.string,
-    nextPage: PropTypes.string,
+    currentPage: PropTypes.number.isRequired,
+    previousPageAvailable: PropTypes.bool,
+    nextPageAvailable: PropTypes.bool,
   };
 
   constructor() {
@@ -45,8 +48,9 @@ export class SearchPage extends React.Component {
       searchForAccountUsers:search,
       lmsAccountId,
       matchingUsers,
-      previousPage,
-      nextPage
+      currentPage,
+      previousPageAvailable,
+      nextPageAvailable
     } = this.props;
     const { searchTerm } = this.state;
     const renderedUsers = matchingUsers.map(user => (
@@ -80,9 +84,12 @@ export class SearchPage extends React.Component {
             {renderedUsers}
           </tbody>
         </table>
-        <a href="#" onClick={() => search(lmsAccountId, searchTerm, previousPage)}>Previous</a>
-        ...
-        <a href="#" onClick={() => search(lmsAccountId, searchTerm, nextPage)}>Next</a>
+        <Pagination
+          changePageTo={page => search(lmsAccountId, searchTerm, page)}
+          currentPage={currentPage}
+          previousPageAvailable={previousPageAvailable}
+          nextPageAvailable={nextPageAvailable}
+        />
       </div>
     );
   }

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -25,8 +25,9 @@ describe('SearchPage', () => {
       }
     ],
     lmsAccountId: '1',
-    previousPage: '2',
-    nextPage: '4',
+    currentPage: 2,
+    previousPageAvailable: true,
+    nextPageAvailable: true,
   };
 
   it('renders the search page', () => {
@@ -34,8 +35,9 @@ describe('SearchPage', () => {
       matchingUsers={props.matchingUsers}
       searchForAccountUsers={props.searchForAccountUsers}
       lmsAccountId={props.lmsAccountId}
-      previousPage={props.previousPage}
-      nextPage={props.nextPage}
+      currentPage={props.currentPage}
+      previousPageAvailable={props.previousPageAvailable}
+      nextPageAvailable={props.nextPageAvailable}
     />);
 
     expect(result).toMatchSnapshot();
@@ -49,6 +51,7 @@ describe('SearchPage', () => {
         matchingUsers={props.matchingUsers}
         searchForAccountUsers={props.searchForAccountUsers}
         lmsAccountId={props.lmsAccountId}
+        currentPage={props.currentPage}
       />);
 
       result.find('input').simulate('change', { target: { value: searchTerm } });
@@ -68,6 +71,7 @@ describe('SearchPage', () => {
           matchingUsers={props.matchingUsers}
           searchForAccountUsers={props.searchForAccountUsers}
           lmsAccountId={props.lmsAccountId}
+          currentPage={props.currentPage}
         />);
 
         result.find('input').simulate('change', { target: { value: searchTerm } });

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -108,13 +108,14 @@ describe('SearchPage', () => {
 
         result.find('input').simulate('change', { target: { value: secondSearchTerm } });
 
-        const previousButton = result.find('button').at(1);
-        previousButton.simulate('click');
+        const buttons = result.find('button');
+        const nextButton = buttons.at(buttons.length - 1);
+        nextButton.simulate('click');
 
         expect(props.searchForAccountUsers).toHaveBeenCalledWith(
           props.lmsAccountId,
           firstSearchTerm,
-          props.currentPage - 1,
+          props.currentPage + 1,
         );
       });
     });

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -25,6 +25,8 @@ describe('SearchPage', () => {
       }
     ],
     lmsAccountId: '1',
+    previousPage: '2',
+    nextPage: '4',
   };
 
   it('renders the search page', () => {
@@ -32,6 +34,8 @@ describe('SearchPage', () => {
       matchingUsers={props.matchingUsers}
       searchForAccountUsers={props.searchForAccountUsers}
       lmsAccountId={props.lmsAccountId}
+      previousPage={props.previousPage}
+      nextPage={props.nextPage}
     />);
 
     expect(result).toMatchSnapshot();

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import { SearchPage } from './search_page';
 
@@ -80,6 +80,41 @@ describe('SearchPage', () => {
         expect(props.searchForAccountUsers).not.toHaveBeenCalledWith(
           props.lmsAccountId,
           searchTerm,
+        );
+      });
+    });
+
+    describe('when the user updates the value in the search input field', () => {
+      it('does not affect the paged results', () => {
+        spyOn(props, 'searchForAccountUsers');
+        const firstSearchTerm = 'john';
+        const secondSearchTerm = 'jones';
+        const result = mount(<SearchPage
+          matchingUsers={props.matchingUsers}
+          searchForAccountUsers={props.searchForAccountUsers}
+          lmsAccountId={props.lmsAccountId}
+          currentPage={props.currentPage}
+          previousPageAvailable={props.previousPageAvailable}
+          nextPageAvailable={props.nextPageAvailable}
+        />);
+
+        result.find('input').simulate('change', { target: { value: firstSearchTerm } });
+        result.find('button[type="submit"]').simulate('click');
+
+        expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+          props.lmsAccountId,
+          firstSearchTerm,
+        );
+
+        result.find('input').simulate('change', { target: { value: secondSearchTerm } });
+
+        const previousButton = result.find('button').at(1);
+        previousButton.simulate('click');
+
+        expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+          props.lmsAccountId,
+          firstSearchTerm,
+          props.currentPage - 1,
         );
       });
     });

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -6,9 +6,13 @@ export default (state = initialState(), action) => {
   switch (action.type) {
 
     case ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE: {
-      const matchingUsers = action.payload;
+      const {
+        matching_users:matchingUsers,
+        previous_page:previousPage,
+        next_page:nextPage
+      } = action.payload;
 
-      return { ...state, ...{ matchingUsers } };
+      return { ...state, ...{ matchingUsers, previousPage, nextPage } };
     }
 
     default:

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -1,18 +1,25 @@
 import { Constants as ApplicationConstants } from '../actions/application';
 
-const initialState = () => ({ matchingUsers: [] });
+const defaultPage = 1;
+const initialState = () => ({ matchingUsers: [], currentPage: defaultPage });
 
 export default (state = initialState(), action) => {
   switch (action.type) {
 
+    case ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS: {
+      const currentPage = action.params.page || defaultPage;
+
+      return { ...state, ...{ currentPage } };
+    }
+
     case ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE: {
       const {
         matching_users:matchingUsers,
-        previous_page:previousPage,
-        next_page:nextPage
+        previous_page_available:previousPageAvailable,
+        next_page_available:nextPageAvailable,
       } = action.payload;
 
-      return { ...state, ...{ matchingUsers, previousPage, nextPage } };
+      return { ...state, ...{ matchingUsers, previousPageAvailable, nextPageAvailable } };
     }
 
     default:

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -2,13 +2,40 @@ import applicationReducer from './application';
 import { Constants as ApplicationConstants } from '../actions/application';
 
 describe('application reducer', () => {
-  let initialState = () => ({ matchingUsers: [] });
+  const initialState = () => ({ matchingUsers: [], currentPage: 1 });
 
   describe('initial state', () => {
     it('returns empty state', () => {
       const state = applicationReducer(initialState, {});
 
       expect(state).toEqual(initialState);
+    });
+  });
+
+  describe('SEARCH_FOR_ACCOUNT_USERS', () => {
+    it('updates the currentPage', () => {
+      const page = 2;
+      const action = {
+        type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS,
+        params: { page }
+      };
+
+      const state = applicationReducer(initialState, action);
+
+      expect(state.currentPage).toEqual(page);
+    });
+
+    describe('when no page is given', () => {
+      it('defaults the currentPage to 1', () => {
+        const action = {
+          type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS,
+          params: {}
+        };
+
+        const state = applicationReducer(initialState, action);
+
+        expect(state.currentPage).toEqual(1);
+      });
     });
   });
 
@@ -29,28 +56,28 @@ describe('application reducer', () => {
       expect(state.matchingUsers).toEqual(matchingUsers);
     });
 
-    it('updates previousPage', () => {
-      const previousPage = '2'
+    it('updates previousPageAvailable', () => {
+      const previousPageAvailable = true;
       const action = {
         type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
-        payload: { previous_page: previousPage },
+        payload: { previous_page_available: previousPageAvailable },
       };
 
       const state = applicationReducer(initialState, action);
 
-      expect(state.previousPage).toEqual(previousPage);
+      expect(state.previousPageAvailable).toEqual(previousPageAvailable);
     });
 
     it('updates nextPage', () => {
-      const nextPage = '4';
+      const nextPageAvailable = true;
       const action = {
         type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
-        payload: { next_page: nextPage },
+        payload: { next_page_available: nextPageAvailable },
       };
 
       const state = applicationReducer(initialState, action);
 
-      expect(state.nextPage).toEqual(nextPage);
+      expect(state.nextPageAvailable).toEqual(nextPageAvailable);
     });
   });
 });

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -13,7 +13,7 @@ describe('application reducer', () => {
   });
 
   describe('SEARCH_FOR_ACCOUNT_USERS_DONE', () => {
-    it('updates matchingUsers with the response payload', () => {
+    it('updates matchingUsers', () => {
       const matchingUsers = [
         { id: 1, name: 'Student 1' },
         { id: 2, name: 'Student 2' },
@@ -21,7 +21,7 @@ describe('application reducer', () => {
       ];
       const action = {
         type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
-        payload: matchingUsers,
+        payload: { matching_users: matchingUsers },
       };
 
       const state = applicationReducer(initialState, action);
@@ -29,18 +29,28 @@ describe('application reducer', () => {
       expect(state.matchingUsers).toEqual(matchingUsers);
     });
 
-    describe('if there are no matching users', () => {
-      it('updates matchingUsers to an empty list', () => {
-        initialState = () => ({ matchingUsers: [{ id: 1, name: 'Student 1' }] });
-        const action = {
-          type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
-          payload: [],
-        };
+    it('updates previousPage', () => {
+      const previousPage = '2'
+      const action = {
+        type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
+        payload: { previous_page: previousPage },
+      };
 
-        const state = applicationReducer(initialState, action);
+      const state = applicationReducer(initialState, action);
 
-        expect(state.matchingUsers).toEqual([]);
-      });
+      expect(state.previousPage).toEqual(previousPage);
+    });
+
+    it('updates nextPage', () => {
+      const nextPage = '4';
+      const action = {
+        type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
+        payload: { next_page: nextPage },
+      };
+
+      const state = applicationReducer(initialState, action);
+
+      expect(state.nextPage).toEqual(nextPage);
     });
   });
 });

--- a/client/common/components/common/__snapshots__/pagination.spec.jsx.snap
+++ b/client/common/components/common/__snapshots__/pagination.spec.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination renders the pagination UI 1`] = `
+<nav>
+  <ul>
+    <button
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      &lt;
+    </button>
+    <button
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      &gt;
+    </button>
+  </ul>
+</nav>
+`;

--- a/client/common/components/common/pagination.jsx
+++ b/client/common/components/common/pagination.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class Pagination extends React.Component {
+  static propTypes = {
+    changePageTo: PropTypes.func.isRequired, // A function that accepts the new page number.
+    currentPage: PropTypes.number,
+    previousPageAvailable: PropTypes.bool,
+    nextPageAvailable: PropTypes.bool,
+  }
+
+  renderPreviousButton() {
+    const { previousPageAvailable } = this.props;
+
+    return (
+      <button
+        type="button"
+        disabled={!previousPageAvailable}
+        onClick={() => { this.handlePreviousPageClick(); }}
+      >
+        &lt;
+      </button>
+    );
+  }
+
+  renderNextButton() {
+    const { nextPageAvailable } = this.props;
+
+    return (
+      <button
+        type="button"
+        disabled={!nextPageAvailable}
+        onClick={() => { this.handleNextPageClick(); }}
+      >
+        &gt;
+      </button>
+    );
+  }
+
+  handlePreviousPageClick() {
+    const { changePageTo, currentPage } = this.props;
+
+    changePageTo(currentPage - 1);
+  }
+
+  handleNextPageClick() {
+    const { changePageTo, currentPage } = this.props;
+
+    changePageTo(currentPage + 1);
+  }
+
+  render() {
+    return (
+      <nav>
+        <ul>
+          {this.renderPreviousButton()}
+          {this.renderNextButton()}
+        </ul>
+      </nav>
+    );
+  }
+}
+
+export default Pagination;

--- a/client/common/components/common/pagination.spec.jsx
+++ b/client/common/components/common/pagination.spec.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Pagination from './pagination';
+
+describe('Pagination', () => {
+  const props = {
+    changePageTo: () => {},
+    currentPage: 2,
+    previousPageAvailable: true,
+    nextPageAvailable: true,
+  };
+
+  it('renders the pagination UI', () => {
+    const result = shallow(<Pagination
+      changePageTo={props.changePageTo}
+      currentPage={props.currentPage}
+      previousPageAvailable={props.previousPageAvailable}
+      nextPageAvailable={props.nextPageAvailable}
+    />);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  describe('when the user clicks the previous button', () => {
+    it('navigates to the previous page', () => {
+      spyOn(props, 'changePageTo');
+      const result = shallow(<Pagination
+        changePageTo={props.changePageTo}
+        currentPage={props.currentPage}
+        previousPageAvailable={props.previousPageAvailable}
+        nextPageAvailable={props.nextPageAvailable}
+      />);
+
+      const previousButton = result.find('button').first();
+      previousButton.simulate('click');
+
+      expect(props.changePageTo).toHaveBeenCalledWith(
+        props.currentPage - 1,
+      );
+    });
+  });
+
+  describe('when the user clicks the next button', () => {
+    it('navigates to the next page', () => {
+      spyOn(props, 'changePageTo');
+      const result = shallow(<Pagination
+        changePageTo={props.changePageTo}
+        currentPage={props.currentPage}
+        previousPageAvailable={props.previousPageAvailable}
+        nextPageAvailable={props.nextPageAvailable}
+      />);
+
+      const nextButton = result.find('button').last();
+      nextButton.simulate('click');
+
+      expect(props.changePageTo).toHaveBeenCalledWith(
+        props.currentPage + 1,
+      );
+    });
+  });
+
+  describe('when there is no previous page available', () => {
+    it('disables the previous button', () => {
+      const result = shallow(<Pagination
+        changePageTo={props.changePageTo}
+        currentPage={props.currentPage}
+        previousPageAvailable={false}
+        nextPageAvailable={props.nextPageAvailable}
+      />);
+
+      const previousButton = result.find('button').first();
+
+      expect(previousButton.prop('disabled')).toBe(true);
+    });
+  });
+
+  describe('when there is no next page available', () => {
+    it('disables the next button', () => {
+      const result = shallow(<Pagination
+        changePageTo={props.changePageTo}
+        currentPage={props.currentPage}
+        previousPageAvailable={props.previousPageAvailable}
+        nextPageAvailable={false}
+      />);
+
+      const nextButton = result.find('button').last();
+
+      expect(nextButton.prop('disabled')).toBe(true);
+    });
+  });
+});

--- a/spec/controllers/api/canvas_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_users_controller_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe Api::CanvasUsersController, type: :controller do
       expect(parsed_response["matching_users"].last["name"]).to eq("Thomas Jefferson")
     end
 
-    it "returns the previous page number" do
+    it "returns the availability of a previous page" do
       response = get(:index, params: params)
 
-      expect(JSON.parse(response.body)["previous_page"]).to eq("2")
+      expect(JSON.parse(response.body)["previous_page_available"]).to eq(true)
     end
 
-    it "returns the next page number" do
+    it "returns the availability of a next page" do
       response = get(:index, params: params)
 
-      expect(JSON.parse(response.body)["next_page"]).to eq("4")
+      expect(JSON.parse(response.body)["next_page_available"]).to eq(true)
     end
   end
 end

--- a/spec/controllers/api/canvas_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_users_controller_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Api::CanvasUsersController, type: :controller do
+  before do
+    setup_application_instance
+
+    user = create(:user)
+    user.confirm
+    request.headers["Authorization"] = AuthToken.issue_token(user_id: user.id)
+  end
+
+  describe "GET #index" do
+    let(:params) do
+      {
+        canvas_account_id: 308,
+        search_term: "johnson",
+      }
+    end
+
+    it "returns matching users" do
+      response = get(:index, params: params)
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response["matching_users"].first["name"]).to eq("George Washington")
+      expect(parsed_response["matching_users"].last["name"]).to eq("Thomas Jefferson")
+    end
+
+    it "returns the previous page number" do
+      response = get(:index, params: params)
+
+      expect(JSON.parse(response.body)["previous_page"]).to eq("2")
+    end
+
+    it "returns the next page number" do
+      response = get(:index, params: params)
+
+      expect(JSON.parse(response.body)["next_page"]).to eq("4")
+    end
+  end
+end

--- a/spec/controllers/concerns/canvas_support_spec.rb
+++ b/spec/controllers/concerns/canvas_support_spec.rb
@@ -350,16 +350,16 @@ describe ApplicationController, type: :controller do
     end
   end
 
-  describe "page number methods" do
+  describe "page methods" do
     class WrapperClass
       include Concerns::CanvasSupport
 
-      def get_previous_page_number(canvas_response)
-        previous_page_number(canvas_response)
+      def get_previous_page_available?(canvas_response)
+        previous_page_available?(canvas_response)
       end
 
-      def get_next_page_number(canvas_response)
-        next_page_number(canvas_response)
+      def get_next_page_available?(canvas_response)
+        next_page_available?(canvas_response)
       end
     end
 
@@ -367,52 +367,50 @@ describe ApplicationController, type: :controller do
       @wrapper_class ||= WrapperClass.new
     end
 
-    describe "#previous_page_number" do
+    describe "#previous_page_available?" do
       context "when there is a 'prev' link" do
-        it "returns the page number of the 'prev' link" do
-          page_number = "2"
+        it "returns true" do
           canvas_response = OpenStruct.new(
-            headers: { "Link" => "<www.example.com?page=3&per_page=10>; rel=\"current\"," \
-                      "<www.example.com?page=#{page_number}&per_page=10>; rel=\"prev\"" }
+            headers: { "link" => "<www.example.com?opaque_current>; rel=\"current\"," \
+                      "<www.example.com?opaque_prev>; rel=\"prev\"" },
           )
 
-          expect(wrapper_class.get_previous_page_number(canvas_response)).to eq(page_number)
+          expect(wrapper_class.get_previous_page_available?(canvas_response)).to be true
         end
       end
 
       context "when there is not a 'prev' link" do
-        it "returns nil" do
+        it "returns false" do
           canvas_response = OpenStruct.new(
-            headers: { "Link" => "<www.example.com?page=3&per_page=10>; rel=\"current\"," \
-                      "<www.example.com?page=4&per_page=10>; rel=\"next\"" }
+            headers: { "link" => "<www.example.com?opaque_current>; rel=\"current\"," \
+                      "<www.example.com?opaque_next>; rel=\"next\"" },
           )
 
-          expect(wrapper_class.get_previous_page_number(canvas_response)).to be nil
+          expect(wrapper_class.get_previous_page_available?(canvas_response)).to be false
         end
       end
     end
 
-    describe "#next_page_number" do
+    describe "#next_page_available?" do
       context "when there is a 'next' link" do
-        it "returns the page number of the 'next' link" do
-          page = "4"
+        it "returns true" do
           canvas_response = OpenStruct.new(
-            headers: { "Link" => "<www.example.com?page=3&per_page=10>; rel=\"current\"," \
-                      "<www.example.com?page=#{page}&per_page=10>; rel=\"next\"" }
+            headers: { "link" => "<www.example.com?opaque_current>; rel=\"current\"," \
+                      "<www.example.com?opaque_next>; rel=\"next\"" },
           )
 
-          expect(wrapper_class.get_next_page_number(canvas_response)).to eq(page)
+          expect(wrapper_class.get_next_page_available?(canvas_response)).to eq true
         end
       end
 
       context "when there is not a 'next' link" do
-        it "returns nil" do
+        it "returns false" do
           canvas_response = OpenStruct.new(
-            headers: { "Link" => "<www.example.com?page=3&per_page=10>; rel=\"current\"," \
-                      "<www.example.com?page=2&per_page=10>; rel=\"prev\"" }
+            headers: { "link" => "<www.example.com?opaque_current>; rel=\"current\"," \
+                      "<www.example.com?opaque_prev>; rel=\"prev\"" },
           )
 
-          expect(wrapper_class.get_next_page_number(canvas_response)).to be nil
+          expect(wrapper_class.get_next_page_available?(canvas_response)).to be false
         end
       end
     end

--- a/spec/support/webmock_requests.rb
+++ b/spec/support/webmock_requests.rb
@@ -47,6 +47,29 @@ canvas_assignment_submissions_sections = '[{"assignment_id": 23,"assignment": "A
 canvas_course_assignment = "{\"id\":4,\"name\":\"some assignment\",\"description\":\"\\u003cp\\u003eDo the following:\\u003c/p\\u003e...\",\"created_at\":\"2012-07-01T23:59:00-06:00\",\"updated_at\":\"2012-07-01T23:59:00-06:00\",\"due_at\":\"2012-07-01T23:59:00-06:00\",\"lock_at\":\"2012-07-01T23:59:00-06:00\",\"unlock_at\":\"2012-07-01T23:59:00-06:00\",\"has_overrides\":true,\"all_dates\":null,\"course_id\":123,\"html_url\":\"https://...\",\"submissions_download_url\":\"https://example.com/courses/:course_id/assignments/:id/submissions?zip=1\",\"assignment_group_id\":2,\"due_date_required\":true,\"allowed_extensions\":[\"docx\",\"ppt\"],\"max_name_length\":15,\"turnitin_enabled\":true,\"vericite_enabled\":true,\"turnitin_settings\":null,\"grade_group_students_individually\":false,\"external_tool_tag_attributes\":{\"resource_link_id\":\"123abc\"},\"peer_reviews\":false,\"automatic_peer_reviews\":false,\"peer_review_count\":0,\"peer_reviews_assign_at\":\"2012-07-01T23:59:00-06:00\",\"intra_group_peer_reviews\":false,\"group_category_id\":1,\"needs_grading_count\":17,\"needs_grading_count_by_section\":[{\"section_id\":\"123456\",\"needs_grading_count\":5},{\"section_id\":\"654321\",\"needs_grading_count\":0}],\"position\":1,\"post_to_sis\":true,\"integration_id\":\"12341234\",\"integration_data\":\"12341234\",\"muted\":null,\"points_possible\":12,\"submission_types\":[\"online_text_entry\"],\"has_submitted_submissions\":true,\"grading_type\":\"points\",\"grading_standard_id\":null,\"published\":true,\"unpublishable\":false,\"only_visible_to_overrides\":false,\"locked_for_user\":false,\"lock_info\":null,\"lock_explanation\":\"This assignment is locked until September 1 at 12:00am\",\"quiz_id\":620,\"anonymous_submissions\":false,\"discussion_topic\":null,\"freeze_on_copy\":false,\"frozen\":false,\"frozen_attributes\":[\"title\"],\"submission\":null,\"use_rubric_for_grading\":true,\"rubric_settings\":\"{'points_possible'=\\u003e12}\",\"rubric\":null,\"assignment_visibility\":[137,381,572],\"overrides\":null,\"omit_from_final_grade\":true}"
 canvas_course_attachment = "{\"public_url\":\"https://example-bucket.s3.amazonaws.com/example-namespace/attachments/1/example-filename?AWSAccessKeyId=example-key\\u0026Expires=1400000000\\u0026Signature=example-signature\"}"
 
+canvas_account_users = "[{
+  \"id\":1,
+  \"name\":\"George Washington\",
+  \"created_at\":\"2020-03-06T15:51:28-07:00\",
+  \"sortable_name\":\"Washington, George\",
+  \"short_name\":\"Goerge Washington\",
+  \"sis_user_id\":\"george_123\",
+  \"integration_id\":null,
+  \"sis_import_id\":null,
+  \"login_id\":\"countryfather@revolution.com\"
+},
+{
+  \"id\":2,
+  \"name\":\"Thomas Jefferson\",
+  \"created_at\":\"2020-03-06T15:49:48-07:00\",
+  \"sortable_name\":\"Jefferson, Thomas\",
+  \"short_name\":\"Thomas Jefferson\",
+  \"sis_user_id\":\"thomas_123\",
+  \"integration_id\":null,
+  \"sis_import_id\":null,
+  \"login_id\":\"idodeclare@revolution.com\"
+}]"
+
 RSpec.configure do |config|
   config.before(:each) do
     # #######################################################################################
@@ -208,6 +231,17 @@ RSpec.configure do |config|
         status: 200,
         body: canvas_account,
         headers: canvas_headers,
+      )
+
+    stub_request(:get, %r|http[s]*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/v1/accounts/\d+/users|).
+      to_return(
+        status: 200,
+        body: canvas_account_users,
+        headers: canvas_headers(
+          "Link" => "<www.example.com?page=3&per_page=10>; rel=\"current\"," \
+                    "<www.example.com?page=2&per_page=10>; rel=\"prev\"," \
+                    "<www.example.com?page=4&per_page=10>; rel=\"next\"",
+        ),
       )
 
     stub_request(:get, %r|http[s]*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/v1/course_accounts|).


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171680475](https://www.pivotaltracker.com/story/show/171680475)

This branch adds pagination for the search results. It allows a user to move to the next and previous pages of results when they're available.

This uses the default page size from the Canvas API which is currently 10. If we wanted to add more results, it would be trivial to alter that number.

## Tradeoffs & Alternatives
We discussed at some length the possibility of providing more sophisticated pagination that allows the user to do things like jump to the first and last pages and see the total number of pages. Ultimately, we decided to stick with this basic next/previous implementation because it seems sufficient and the more sophisticated version didn't seem like it was worth the development time.

Our conversation concerning this can be found in the Pivotal Tracker story linked to at the top of this pull request.

## Demo
![search_paging](https://user-images.githubusercontent.com/6520489/77106499-cb26d080-69e4-11ea-8330-747fe343c7e5.gif)