### PR TITLE
Set Rubocop in Gemfile to Match Hound Config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ group :development do
 end
 
 group :development, :linter do
-  gem "rubocop"
+  gem "rubocop", "=0.75.0"
   gem "rubocop-performance"
   gem "rubocop-rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       omniauth (~> 1.9)
     orm_adapter (0.5.0)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.0.4)
       ast (~> 2.4.0)
     pg (1.2.2)
     pry (0.12.2)
@@ -313,7 +313,6 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.4)
     rolify (5.2.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -336,12 +335,11 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.80.0)
+    rubocop (0.75.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
-      rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.5.2)
@@ -476,7 +474,7 @@ DEPENDENCIES
   rest-client
   rolify
   rspec-rails
-  rubocop
+  rubocop (= 0.75.0)
   rubocop-performance
   rubocop-rails
   ruby-debug-ide


### PR DESCRIPTION
Our Gemfile doesn't specify a version of Rubocop, but our Hound configuration specifies `0.75.0`. I think we should set them to the same version so we don't run into compatibility issues.

I, for example, couldn't run Rubocop locally because our `.rubocop.yml` config raises an error in the current version fo Rubocop.