### PR TITLE
Remove Unnecessary `include_sub_accounts` Param

### DIFF
--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -15,6 +15,5 @@ export const searchForAccountUsers = (lmsAccountId, searchTerm) => ({
   url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
   params: {
     search_term: searchTerm,
-    include_sub_accounts: true,
   },
 });

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -11,7 +11,6 @@ describe('application actions', () => {
         url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
         params: {
           search_term: searchTerm,
-          include_sub_accounts: true,
         },
       };
 
@@ -28,7 +27,6 @@ describe('application actions', () => {
           url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
           params: {
             search_term: searchTerm,
-            include_sub_accounts: true,
           },
         };
 


### PR DESCRIPTION
Pivotal Tracker: [#171634698](https://www.pivotaltracker.com/story/show/171634698)

After more testing, it looks like the [list users in account](https://canvas.instructure.com/doc/api/users.html#method.users.api_index) endpoint already includes users from child sub-accounts, so we won't have to do anything ourselves to make that work.

This removes the `include_sub_accounts` parameter since it's not necessary.

I added this parameter when I was originally writing the action, and I planned on adding support for it in the `CanvasUsersController` later. I never updated the controller though because I realized we didn't need it.