### PR TITLE
Add Edit User Modal

### DIFF
--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditUserModal renders the edit user modal 1`] = `
+<Modal
+  ariaHideApp={true}
+  bodyOpenClassName="ReactModal__Body--open"
+  closeTimeoutMS={0}
+  contentLabel="Edit User Modal"
+  isOpen={true}
+  onRequestClose={[Function]}
+  parentSelector={[Function]}
+  portalClassName="ReactModalPortal"
+  role="dialog"
+  shouldCloseOnEsc={true}
+  shouldCloseOnOverlayClick={true}
+  shouldFocusAfterRender={true}
+  shouldReturnFocusAfterClose={true}
+>
+  <h2>
+    Edit User
+  </h2>
+  <p>
+    Editing
+    Washington, George
+  </p>
+</Modal>
+`;

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -19,6 +19,16 @@ exports[`EditUserModal renders the edit user modal 1`] = `
   <h2>
     Edit User
   </h2>
+  <button
+    onClick={[Function]}
+    type="button"
+  >
+    <i
+      className="material-icons"
+    >
+      close
+    </i>
+  </button>
   <p>
     Editing
     Washington, George

--- a/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
@@ -1,22 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UserSearchResult renders the user as a search result 1`] = `
-<tr>
-  <td>
-    Washington, George
-  </td>
-  <td>
-    countryfather@revolution.com
-  </td>
-  <td>
-    admin
-    teacher
-  </td>
-  <td>
-    countryfather@revolution.com
-  </td>
-  <td>
-    george_123
-  </td>
-</tr>
+<Fragment>
+  <tr>
+    <td>
+      <button
+        onClick={[Function]}
+        type="button"
+      >
+        Washington, George
+      </button>
+    </td>
+    <td>
+      countryfather@revolution.com
+    </td>
+    <td>
+      admin
+      teacher
+    </td>
+    <td>
+      countryfather@revolution.com
+    </td>
+    <td>
+      george_123
+    </td>
+  </tr>
+  <EditUserModal
+    closeModal={[Function]}
+    isOpen={false}
+    userToEdit={
+      Object {
+        "email": "countryfather@revolution.com",
+        "login_id": "countryfather@revolution.com",
+        "roles": Array [
+          "admin",
+          "teacher",
+        ],
+        "sis_user_id": "george_123",
+        "sortable_name": "Washington, George",
+      }
+    }
+  />
+</Fragment>
 `;

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactModal from 'react-modal';
+
+export default class EditUserModal extends React.Component {
+  static propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    closeModal: PropTypes.func.isRequired,
+    userToEdit: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { isOpen, closeModal, userToEdit:user } = this.props;
+
+    return (
+      <ReactModal
+        contentLabel="Edit User Modal"
+        isOpen={isOpen}
+        onRequestClose={closeModal}
+      >
+        <h2>Edit User</h2>
+        <p>
+          Editing
+          {user.sortable_name}
+        </p>
+      </ReactModal>
+    );
+  }
+}

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -19,6 +19,9 @@ export default class EditUserModal extends React.Component {
         onRequestClose={closeModal}
       >
         <h2>Edit User</h2>
+        <button type="button" onClick={closeModal}>
+          <i className="material-icons">close</i>
+        </button>
         <p>
           Editing
           {user.sortable_name}

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -4,17 +4,35 @@ import { shallow } from 'enzyme';
 import EditUserModal from './edit_user_modal';
 
 describe('EditUserModal', () => {
-  const user = {
-    sortable_name: 'Washington, George',
-    email: 'countryfather@revolution.com',
-    roles: ['admin', 'teacher'],
-    login_id: 'countryfather@revolution.com',
-    sis_user_id: 'george_123',
+  const props = {
+    closeModal: () => {},
+    user: {
+      sortable_name: 'Washington, George',
+      email: 'countryfather@revolution.com',
+      roles: ['admin', 'teacher'],
+      login_id: 'countryfather@revolution.com',
+      sis_user_id: 'george_123',
+    },
   };
 
   it('renders the edit user modal', () => {
-    const result = shallow(<EditUserModal isOpen closeModal={() => {}} userToEdit={user} />);
+    const modal = shallow(
+      <EditUserModal isOpen closeModal={props.closeModal} userToEdit={props.user} />
+    );
 
-    expect(result).toMatchSnapshot();
+    expect(modal).toMatchSnapshot();
+  });
+
+  describe('when the close/x button is clicked', () => {
+    it('closes the modal', () => {
+      spyOn(props, 'closeModal');
+      const modal = shallow(
+        <EditUserModal isOpen closeModal={props.closeModal} userToEdit={props.user} />
+      );
+
+      modal.find('button').simulate('click');
+
+      expect(props.closeModal).toHaveBeenCalled();
+    });
   });
 });

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import EditUserModal from './edit_user_modal';
+
+describe('EditUserModal', () => {
+  const user = {
+    sortable_name: 'Washington, George',
+    email: 'countryfather@revolution.com',
+    roles: ['admin', 'teacher'],
+    login_id: 'countryfather@revolution.com',
+    sis_user_id: 'george_123',
+  };
+
+  it('renders the edit user modal', () => {
+    const result = shallow(<EditUserModal isOpen closeModal={() => {}} userToEdit={user} />);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/client/apps/user_tool/components/main/user_search_result.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.jsx
@@ -22,7 +22,7 @@ export default class UserSearchResult extends React.Component {
     const { editUserModalIsOpen } = this.state;
 
     return (
-      <>
+      <React.Fragment>
         <tr>
           <td>
             <button type="button" onClick={() => this.showEditUserModal(true)}>
@@ -40,7 +40,7 @@ export default class UserSearchResult extends React.Component {
           closeModal={() => this.showEditUserModal(false)}
           userToEdit={user}
         />
-      </>
+      </React.Fragment>
     );
   }
 }

--- a/client/apps/user_tool/components/main/user_search_result.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.jsx
@@ -1,22 +1,46 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import EditUserModal from './edit_user_modal';
 
 export default class UserSearchResult extends React.Component {
   static propTypes = {
     user: PropTypes.object.isRequired,
   };
 
+  constructor() {
+    super();
+
+    this.state = { editUserModalIsOpen: false };
+  }
+
+  showEditUserModal(directive) {
+    this.setState({ editUserModalIsOpen: directive });
+  }
+
   render() {
     const { user } = this.props;
+    const { editUserModalIsOpen } = this.state;
 
     return (
-      <tr>
-        <td>{user.sortable_name}</td>
-        <td>{user.email}</td>
-        <td>{user.roles}</td>
-        <td>{user.login_id}</td>
-        <td>{user.sis_user_id}</td>
-      </tr>
+      <>
+        <tr>
+          <td>
+            <button type="button" onClick={() => this.showEditUserModal(true)}>
+              {user.sortable_name}
+            </button>
+          </td>
+          <td>{user.email}</td>
+          <td>{user.roles}</td>
+          <td>{user.login_id}</td>
+          <td>{user.sis_user_id}</td>
+        </tr>
+
+        <EditUserModal
+          isOpen={editUserModalIsOpen}
+          closeModal={() => this.showEditUserModal(false)}
+          userToEdit={user}
+        />
+      </>
     );
   }
 }

--- a/client/apps/user_tool/components/main/user_search_result.spec.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.spec.jsx
@@ -17,4 +17,18 @@ describe('UserSearchResult', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  describe('when the edit user button is clicked', () => {
+    it('opens the edit user modal', () => {
+      const userSearchResult = shallow(<UserSearchResult user={user} />);
+
+      let modalComponent = userSearchResult.find('EditUserModal');
+      expect(modalComponent.prop('isOpen')).toBe(false);
+
+      userSearchResult.find('button').simulate('click');
+
+      modalComponent = userSearchResult.find('EditUserModal');
+      expect(modalComponent.prop('isOpen')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171524370](https://www.pivotaltracker.com/story/show/171524370)

This adds a modal for editing users. The modal is activated by clicking on the name of a user in the search results. The modal doesn't actually allow you to edit the user yet; that will be added later.

## Tradeoffs & Alternatives
This implementation renders a separate edit modal for each of the users displayed in search results.

I considered rendering a single edit modal to be used for all of the displayed users; that seemed to be cleaner as far as the DOM is concerned. Rendering a modal for each user seemed to simplify the code though, and that seems more valuable. Also, rendering a separate modal for each entity seems to be the pattern we use elsewhere in our applications.

## Demo
![edit_user_modal](https://user-images.githubusercontent.com/6520489/77190174-6465ed80-6a9e-11ea-8e57-60140529f476.gif)