### PR TITLE
Include User Emails When Fetching Account Users

### DIFF
--- a/app/controllers/api/canvas_users_controller.rb
+++ b/app/controllers/api/canvas_users_controller.rb
@@ -4,14 +4,14 @@ class Api::CanvasUsersController < Api::ApiApplicationController
   before_action :validate_token
 
   def index
-    canvas_response = canvas_api.proxy(
-      "LIST_USERS_IN_ACCOUNT",
-      {
-        account_id: params[:canvas_account_id],
-        search_term: params[:search_term],
-        page: params[:page],
-      },
-    )
+    # We're manually constructing the URL here and using `api_get_request` instead of
+    # `canvas_api.proxy("LIST_USERS_IN_ACCOUNT", params)` because `proxy("LIST_USERS_IN_ACCOUNT")`
+    # doesn't support the `include` param since it's undocumented.
+    canvas_url = "accounts/#{params[:canvas_account_id]}/users" \
+      "?search_term=#{params[:search_term]}&include[]=email"
+    canvas_url += "&page=#{params[:page]}" if params[:page] # You get a 404 if you pass `&page=`
+
+    canvas_response = canvas_api.api_get_request(canvas_url)
 
     render(
       json: {

--- a/spec/controllers/api/canvas_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_users_controller_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Api::CanvasUsersController, type: :controller do
       expect(parsed_response["matching_users"].last["name"]).to eq("Thomas Jefferson")
     end
 
+    it "includes emails in user data" do
+      response = get(:index, params: params)
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response["matching_users"].first["email"]).to eq("countryfather@revolution.com")
+      expect(parsed_response["matching_users"].last["email"]).to eq("idodeclare@revolution.com")
+    end
+
     it "returns the availability of a previous page" do
       response = get(:index, params: params)
 

--- a/spec/support/webmock_requests.rb
+++ b/spec/support/webmock_requests.rb
@@ -70,6 +70,31 @@ canvas_account_users = "[{
   \"login_id\":\"idodeclare@revolution.com\"
 }]"
 
+canvas_account_users_with_emails = "[{
+  \"id\":1,
+  \"name\":\"George Washington\",
+  \"created_at\":\"2020-03-06T15:51:28-07:00\",
+  \"sortable_name\":\"Washington, George\",
+  \"short_name\":\"Goerge Washington\",
+  \"sis_user_id\":\"george_123\",
+  \"integration_id\":null,
+  \"sis_import_id\":null,
+  \"login_id\":\"countryfather@revolution.com\",
+  \"email\":\"countryfather@revolution.com\"
+},
+{
+  \"id\":2,
+  \"name\":\"Thomas Jefferson\",
+  \"created_at\":\"2020-03-06T15:49:48-07:00\",
+  \"sortable_name\":\"Jefferson, Thomas\",
+  \"short_name\":\"Thomas Jefferson\",
+  \"sis_user_id\":\"thomas_123\",
+  \"integration_id\":null,
+  \"sis_import_id\":null,
+  \"login_id\":\"idodeclare@revolution.com\",
+  \"email\":\"idodeclare@revolution.com\"
+}]"
+
 RSpec.configure do |config|
   config.before(:each) do
     # #######################################################################################
@@ -237,6 +262,17 @@ RSpec.configure do |config|
       to_return(
         status: 200,
         body: canvas_account_users,
+        headers: canvas_headers(
+          "Link" => "<www.example.com?page=3&per_page=10>; rel=\"current\"," \
+                    "<www.example.com?page=2&per_page=10>; rel=\"prev\"," \
+                    "<www.example.com?page=4&per_page=10>; rel=\"next\"",
+        ),
+      )
+
+    stub_request(:get, %r|http[s]*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/v1/accounts/\d+/users.*include\[\]=email|).
+      to_return(
+        status: 200,
+        body: canvas_account_users_with_emails,
         headers: canvas_headers(
           "Link" => "<www.example.com?page=3&per_page=10>; rel=\"current\"," \
                     "<www.example.com?page=2&per_page=10>; rel=\"prev\"," \


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171825565](https://www.pivotaltracker.com/story/show/171825565)

This updates the API call to Canvas to include user emails. This will allow us to display the user email on the search results page and in the edit modal.

We didn't fetch them previously because I didn't realize you could pass an `include` param to the [List users in account](https://canvas.instructure.com/doc/api/users.html#method.users.api_index) endpoint to request user emails. I was thinking we'd have to make a separate API call.

## Demo
![image](https://user-images.githubusercontent.com/6520489/77356714-7c42a900-6d0c-11ea-933b-88bd88552d01.png)