### PR TITLE
Add Edit User Form

### DIFF
--- a/app/controllers/api/canvas_users_controller.rb
+++ b/app/controllers/api/canvas_users_controller.rb
@@ -62,9 +62,12 @@ class Api::CanvasUsersController < Api::ApiApplicationController
     # We're manually constructing the URL here and using `api_get_request` instead of
     # `canvas_api.proxy("LIST_USERS_IN_ACCOUNT", params)` because `proxy("LIST_USERS_IN_ACCOUNT")`
     # doesn't support the `include` param since it's undocumented.
-    canvas_url = "accounts/#{params[:canvas_account_id]}/users" \
-      "?search_term=#{search_term}&include[]=email"
-    canvas_url += "&page=#{page}" if page # You get a 404 if you pass `&page=`
+    query_params = {
+      search_term: search_term,
+      include: [:email],
+    }
+    query_params[:page] = page if page.present? # You get a 404 if you pass an empty `page` param.
+    canvas_url = "accounts/#{params[:canvas_account_id]}/users?#{query_params.to_query}"
 
     canvas_api.api_get_request(canvas_url)
   end

--- a/app/controllers/api/canvas_users_controller.rb
+++ b/app/controllers/api/canvas_users_controller.rb
@@ -2,6 +2,7 @@ class Api::CanvasUsersController < Api::ApiApplicationController
   include Concerns::CanvasSupport
 
   before_action :validate_token
+  before_action :validate_current_user_lti_admin
 
   def index
     # We're manually constructing the URL here and using `api_get_request` instead of
@@ -44,6 +45,12 @@ class Api::CanvasUsersController < Api::ApiApplicationController
   end
 
   private
+
+  def validate_current_user_lti_admin
+    unless current_user.lti_admin?(jwt_context_id)
+      user_not_authorized "Only account admins are authorized to use this application."
+    end
+  end
 
   def edit_user_on_canvas
     canvas_api.api_put_request(

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -5,7 +5,7 @@ import Network from 'atomic-fuel/libs/constants/network';
 const actions = [];
 
 // Actions that make an api request
-const requests = ['SEARCH_FOR_ACCOUNT_USERS'];
+const requests = ['SEARCH_FOR_ACCOUNT_USERS', 'UPDATE_USER'];
 
 export const Constants = wrapper(actions, requests);
 
@@ -17,4 +17,13 @@ export const searchForAccountUsers = (lmsAccountId, searchTerm, page) => ({
     search_term: searchTerm,
     page,
   },
+});
+
+export const updateUser = (lmsAccountId, userId, userAttributes) => ({
+  type: Constants.UPDATE_USER,
+  method: Network.PUT,
+  url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
+  params: {
+    userAttributes
+  }
 });

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -19,11 +19,25 @@ export const searchForAccountUsers = (lmsAccountId, searchTerm, page) => ({
   },
 });
 
-export const updateUser = (lmsAccountId, userId, userAttributes) => ({
-  type: Constants.UPDATE_USER,
-  method: Network.PUT,
-  url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
-  params: {
-    userAttributes
+export const updateUser = (lmsAccountId, userId, originalUserLoginId, userAttributes) => {
+  const body = {
+    original_user_login_id: originalUserLoginId,
+    user: {
+      name: userAttributes.name,
+      login_id: userAttributes.loginId,
+      sis_user_id: userAttributes.sisUserId,
+      email: userAttributes.email,
+    }
+  };
+
+  if (userAttributes.password !== '') {
+    body.user.password = userAttributes.password;
   }
-});
+
+  return {
+    type: Constants.UPDATE_USER,
+    method: Network.PUT,
+    url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
+    body,
+  };
+};

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -1,4 +1,4 @@
-import { searchForAccountUsers } from './application';
+import { searchForAccountUsers, updateUser } from './application';
 
 describe('application actions', () => {
   describe('searchForAccountUsers', () => {
@@ -36,6 +36,30 @@ describe('application actions', () => {
 
         expect(searchForAccountUsers(lmsAccountId, searchTerm, page)).toEqual(expectedAction);
       });
+    });
+  });
+
+  describe('updateUser', () => {
+    it('generates the correct action', () => {
+      const lmsAccountId = 123;
+      const userId = 45;
+      const userAttributes = {
+        name: 'John Adams',
+        loginId: '',
+        password: '',
+        sisId: 'john_123',
+        email: ''
+      };
+      const expectedAction = {
+        type: 'UPDATE_USER',
+        method: 'put',
+        url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
+        params: {
+          userAttributes
+        }
+      };
+
+      expect(updateUser(lmsAccountId, userId, userAttributes)).toEqual(expectedAction);
     });
   });
 });

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -40,26 +40,60 @@ describe('application actions', () => {
   });
 
   describe('updateUser', () => {
+    const lmsAccountId = 123;
+    const userId = 45;
+    const originalUserLoginId = 'adamsforindepence@greatbritain.com';
+    const userAttributes = {
+      name: 'John Adams',
+      loginId: 'adamsforindependence@revolution.com',
+      password: 'new_password',
+      sisUserId: 'john_123',
+      email: 'adamsforindependence@revolution.com'
+    };
+
     it('generates the correct action', () => {
-      const lmsAccountId = 123;
-      const userId = 45;
-      const userAttributes = {
-        name: 'John Adams',
-        loginId: '',
-        password: '',
-        sisId: 'john_123',
-        email: ''
-      };
       const expectedAction = {
         type: 'UPDATE_USER',
         method: 'put',
         url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
-        params: {
-          userAttributes
+        body: {
+          original_user_login_id: originalUserLoginId,
+          user: {
+            name: userAttributes.name,
+            login_id: userAttributes.loginId,
+            sis_user_id: userAttributes.sisUserId,
+            email: userAttributes.email,
+            password: userAttributes.password,
+          }
         }
       };
 
-      expect(updateUser(lmsAccountId, userId, userAttributes)).toEqual(expectedAction);
+      expect(updateUser(lmsAccountId, userId, originalUserLoginId, userAttributes))
+        .toEqual(expectedAction);
+    });
+
+    describe('when no password is given', () => {
+      it('does not send a password property', () => {
+        delete userAttributes.password;
+
+        const expectedAction = {
+          type: 'UPDATE_USER',
+          method: 'put',
+          url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
+          body: {
+            original_user_login_id: originalUserLoginId,
+            user: {
+              name: userAttributes.name,
+              login_id: userAttributes.loginId,
+              sis_user_id: userAttributes.sisUserId,
+              email: userAttributes.email,
+            }
+          }
+        };
+
+        expect(updateUser(lmsAccountId, userId, originalUserLoginId, userAttributes))
+          .toEqual(expectedAction);
+      });
     });
   });
 });

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -29,9 +29,66 @@ exports[`EditUserModal renders the edit user modal 1`] = `
       close
     </i>
   </button>
-  <p>
-    Editing
-    Washington, George
-  </p>
+  <form>
+    <label
+      htmlFor="user_name"
+    >
+      Name
+    </label>
+    <input
+      id="user_name"
+      name="userName"
+      onChange={[Function]}
+      type="text"
+    />
+    <label
+      htmlFor="user_login_id"
+    >
+      Login ID
+    </label>
+    <input
+      defaultValue="countryfather@revolution.com"
+      id="user_login_id"
+      name="userLoginId"
+      onChange={[Function]}
+      type="text"
+    />
+    <label
+      htmlFor="user_password"
+    >
+      Password
+    </label>
+    <input
+      defaultValue="************"
+      id="user_password"
+      name="userPassword"
+      onChange={[Function]}
+      type="password"
+    />
+    <label
+      htmlFor="user_sis_id"
+    >
+      SIS ID
+    </label>
+    <input
+      defaultValue="george_123"
+      id="user_sis_id"
+      name="userSisId"
+      onChange={[Function]}
+      type="text"
+    />
+    <label
+      htmlFor="user_email"
+    >
+      Email
+    </label>
+    <input
+      defaultValue="countryfather@revolution.com"
+      id="user_email"
+      name="userEmail"
+      onChange={[Function]}
+      type="email"
+    />
+  </form>
 </Modal>
 `;

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -34,61 +34,68 @@ exports[`EditUserModal renders the edit user modal 1`] = `
       htmlFor="user_name"
     >
       Name
+      <input
+        id="user_name"
+        name="name"
+        onChange={[Function]}
+        type="text"
+        value="George Washington"
+      />
     </label>
-    <input
-      id="user_name"
-      name="userName"
-      onChange={[Function]}
-      type="text"
-    />
     <label
       htmlFor="user_login_id"
     >
       Login ID
+      <input
+        id="user_login_id"
+        name="loginId"
+        onChange={[Function]}
+        type="text"
+        value="countryfather@revolution.com"
+      />
     </label>
-    <input
-      defaultValue="countryfather@revolution.com"
-      id="user_login_id"
-      name="userLoginId"
-      onChange={[Function]}
-      type="text"
-    />
     <label
       htmlFor="user_password"
     >
       Password
+      <input
+        id="user_password"
+        name="password"
+        onChange={[Function]}
+        type="password"
+        value=""
+      />
     </label>
-    <input
-      defaultValue="************"
-      id="user_password"
-      name="userPassword"
-      onChange={[Function]}
-      type="password"
-    />
     <label
-      htmlFor="user_sis_id"
+      htmlFor="user_sis_user_id"
     >
       SIS ID
+      <input
+        id="user_sis_user_id"
+        name="sisUserId"
+        onChange={[Function]}
+        type="text"
+        value="george_123"
+      />
     </label>
-    <input
-      defaultValue="george_123"
-      id="user_sis_id"
-      name="userSisId"
-      onChange={[Function]}
-      type="text"
-    />
     <label
       htmlFor="user_email"
     >
       Email
+      <input
+        id="user_email"
+        name="email"
+        onChange={[Function]}
+        type="email"
+        value="countryfather@revolution.com"
+      />
     </label>
-    <input
-      defaultValue="countryfather@revolution.com"
-      id="user_email"
-      name="userEmail"
-      onChange={[Function]}
-      type="email"
-    />
+    <button
+      onClick={[Function]}
+      type="submit"
+    >
+      Update User
+    </button>
   </form>
 </Modal>
 `;

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -62,6 +62,7 @@ exports[`EditUserModal renders the edit user modal 1`] = `
         id="user_password"
         name="password"
         onChange={[Function]}
+        placeholder="****************"
         type="password"
         value=""
       />

--- a/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
@@ -31,7 +31,12 @@ exports[`SearchPage renders the search page 1`] = `
         <th
           scope="col"
         >
-          Email Address
+          Login ID
+        </th>
+        <th
+          scope="col"
+        >
+          SIS ID
         </th>
         <th
           scope="col"
@@ -41,12 +46,7 @@ exports[`SearchPage renders the search page 1`] = `
         <th
           scope="col"
         >
-          Login ID
-        </th>
-        <th
-          scope="col"
-        >
-          SIS ID
+          Email Address
         </th>
       </tr>
     </thead>
@@ -58,12 +58,12 @@ exports[`SearchPage renders the search page 1`] = `
             "email": "countryfather@revolution.com",
             "id": 1,
             "login_id": "countryfather@revolution.com",
+            "name": "George Washington",
             "roles": Array [
               "admin",
               "teacher",
             ],
             "sis_user_id": "george_123",
-            "sortable_name": "Washington, George",
           }
         }
       />
@@ -74,11 +74,11 @@ exports[`SearchPage renders the search page 1`] = `
             "email": "idodeclare@revolution.com",
             "id": 2,
             "login_id": "idodeclare@revolution.com",
+            "name": "Thomas Jefferson",
             "roles": Array [
               "teacher",
             ],
             "sis_user_id": "thomas_123",
-            "sortable_name": "Jefferson, Thomas",
           }
         }
       />

--- a/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
@@ -8,11 +8,14 @@ exports[`UserSearchResult renders the user as a search result 1`] = `
         onClick={[Function]}
         type="button"
       >
-        Washington, George
+        George Washington
       </button>
     </td>
     <td>
       countryfather@revolution.com
+    </td>
+    <td>
+      george_123
     </td>
     <td>
       admin
@@ -20,9 +23,6 @@ exports[`UserSearchResult renders the user as a search result 1`] = `
     </td>
     <td>
       countryfather@revolution.com
-    </td>
-    <td>
-      george_123
     </td>
   </tr>
   <EditUserModal
@@ -32,12 +32,12 @@ exports[`UserSearchResult renders the user as a search result 1`] = `
       Object {
         "email": "countryfather@revolution.com",
         "login_id": "countryfather@revolution.com",
+        "name": "George Washington",
         "roles": Array [
           "admin",
           "teacher",
         ],
         "sis_user_id": "george_123",
-        "sortable_name": "Washington, George",
       }
     }
   />

--- a/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
@@ -25,10 +25,10 @@ exports[`UserSearchResult renders the user as a search result 1`] = `
       countryfather@revolution.com
     </td>
   </tr>
-  <EditUserModal
+  <Connect(EditUserModal)
     closeModal={[Function]}
     isOpen={false}
-    userToEdit={
+    user={
       Object {
         "email": "countryfather@revolution.com",
         "login_id": "countryfather@revolution.com",

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -108,6 +108,7 @@ export class EditUserModal extends React.Component {
               name="password"
               type="password"
               value={userForm.password}
+              placeholder="****************"
               onChange={this.handleInputChange}
             />
           </label>

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -1,26 +1,71 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
+import { connect } from 'react-redux';
+import { updateUser } from '../../actions/application';
 
-export default class EditUserModal extends React.Component {
+const select = state => ({
+  lmsAccountId: state.settings.custom_canvas_account_id,
+});
+
+export class EditUserModal extends React.Component {
   static propTypes = {
+    updateUser: PropTypes.func.isRequired,
     isOpen: PropTypes.bool.isRequired,
     closeModal: PropTypes.func.isRequired,
-    userToEdit: PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired,
+    lmsAccountId: PropTypes.string.isRequired,
   };
 
-  constructor() {
+  constructor(props) {
     super();
+
+    const { user } = props;
+
+    this.state = {
+      userForm: {
+        name: user.name,
+        loginId: user.login_id,
+        password: '',
+        sisUserId: user.sis_user_id,
+        email: user.email
+      }
+    };
 
     this.handleInputChange = this.handleInputChange.bind(this);
   }
 
   handleInputChange(event) {
-    this.setState({ [event.target.name]: event.target.value });
+    const { name, value } = event.target;
+
+    this.setState((state) => {
+      const { userForm } = state;
+
+      userForm[name] = value;
+
+      return { userForm };
+    });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+
+    const {
+      lmsAccountId,
+      user,
+      updateUser:update,
+      closeModal
+    } = this.props;
+    const { userForm } = this.state;
+
+    update(lmsAccountId, user.id, user.login_id, userForm);
+
+    closeModal();
   }
 
   render() {
-    const { isOpen, closeModal, userToEdit:user } = this.props;
+    const { isOpen, closeModal } = this.props;
+    const { userForm } = this.state;
 
     return (
       <ReactModal
@@ -34,22 +79,66 @@ export default class EditUserModal extends React.Component {
         </button>
 
         <form>
-          <label htmlFor="user_name">Name</label>
-          <input id="user_name" type="text" defaultValue={user.name} name="userName" onChange={this.handleInputChange} />
+          <label htmlFor="user_name">
+            Name
+            <input
+              id="user_name"
+              name="name"
+              type="text"
+              value={userForm.name}
+              onChange={this.handleInputChange}
+            />
+          </label>
 
-          <label htmlFor="user_login_id">Login ID</label>
-          <input id="user_login_id" type="text" defaultValue={user.login_id} name="userLoginId" onChange={this.handleInputChange} />
+          <label htmlFor="user_login_id">
+            Login ID
+            <input
+              id="user_login_id"
+              name="loginId"
+              type="text"
+              value={userForm.loginId}
+              onChange={this.handleInputChange}
+            />
+          </label>
 
-          <label htmlFor="user_password">Password</label>
-          <input id="user_password" type="password" defaultValue="************" name="userPassword" onChange={this.handleInputChange} />
+          <label htmlFor="user_password">
+            Password
+            <input
+              id="user_password"
+              name="password"
+              type="password"
+              value={userForm.password}
+              onChange={this.handleInputChange}
+            />
+          </label>
 
-          <label htmlFor="user_sis_id">SIS ID</label>
-          <input id="user_sis_id" type="text" defaultValue={user.sis_user_id} name="userSisId" onChange={this.handleInputChange} />
+          <label htmlFor="user_sis_user_id">
+            SIS ID
+            <input
+              id="user_sis_user_id"
+              name="sisUserId"
+              type="text"
+              value={userForm.sisUserId}
+              onChange={this.handleInputChange}
+            />
+          </label>
 
-          <label htmlFor="user_email">Email</label>
-          <input id="user_email" type="email" defaultValue={user.email} name="userEmail" onChange={this.handleInputChange} />
+          <label htmlFor="user_email">
+            Email
+            <input
+              id="user_email"
+              name="email"
+              type="email"
+              value={userForm.email}
+              onChange={this.handleInputChange}
+            />
+          </label>
+
+          <button type="submit" onClick={event => this.handleSubmit(event)}>Update User</button>
         </form>
       </ReactModal>
     );
   }
 }
+
+export default connect(select, { updateUser })(EditUserModal);

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -9,6 +9,16 @@ export default class EditUserModal extends React.Component {
     userToEdit: PropTypes.object.isRequired,
   };
 
+  constructor() {
+    super();
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+  }
+
+  handleInputChange(event) {
+    this.setState({ [event.target.name]: event.target.value });
+  }
+
   render() {
     const { isOpen, closeModal, userToEdit:user } = this.props;
 
@@ -22,10 +32,23 @@ export default class EditUserModal extends React.Component {
         <button type="button" onClick={closeModal}>
           <i className="material-icons">close</i>
         </button>
-        <p>
-          Editing
-          {user.sortable_name}
-        </p>
+
+        <form>
+          <label htmlFor="user_name">Name</label>
+          <input id="user_name" type="text" defaultValue={user.name} name="userName" onChange={this.handleInputChange} />
+
+          <label htmlFor="user_login_id">Login ID</label>
+          <input id="user_login_id" type="text" defaultValue={user.login_id} name="userLoginId" onChange={this.handleInputChange} />
+
+          <label htmlFor="user_password">Password</label>
+          <input id="user_password" type="password" defaultValue="************" name="userPassword" onChange={this.handleInputChange} />
+
+          <label htmlFor="user_sis_id">SIS ID</label>
+          <input id="user_sis_id" type="text" defaultValue={user.sis_user_id} name="userSisId" onChange={this.handleInputChange} />
+
+          <label htmlFor="user_email">Email</label>
+          <input id="user_email" type="email" defaultValue={user.email} name="userEmail" onChange={this.handleInputChange} />
+        </form>
       </ReactModal>
     );
   }

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -1,23 +1,31 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import EditUserModal from './edit_user_modal';
+import { EditUserModal } from './edit_user_modal';
 
 describe('EditUserModal', () => {
   const props = {
+    updateUser: () => {},
     closeModal: () => {},
     user: {
-      sortable_name: 'Washington, George',
+      name: 'George Washington',
       email: 'countryfather@revolution.com',
       roles: ['admin', 'teacher'],
       login_id: 'countryfather@revolution.com',
       sis_user_id: 'george_123',
     },
+    lmsAccountId: '1',
   };
 
   it('renders the edit user modal', () => {
     const modal = shallow(
-      <EditUserModal isOpen closeModal={props.closeModal} userToEdit={props.user} />
+      <EditUserModal
+        updateUser={props.updateUser}
+        isOpen
+        closeModal={props.closeModal}
+        user={props.user}
+        lmsAccountId={props.lmsAccountId}
+      />
     );
 
     expect(modal).toMatchSnapshot();
@@ -27,12 +35,70 @@ describe('EditUserModal', () => {
     it('closes the modal', () => {
       spyOn(props, 'closeModal');
       const modal = shallow(
-        <EditUserModal isOpen closeModal={props.closeModal} userToEdit={props.user} />
+        <EditUserModal
+          updateUser={props.updateUser}
+          isOpen
+          closeModal={props.closeModal}
+          user={props.user}
+          lmsAccountId={props.lmsAccountId}
+        />
       );
 
-      modal.find('button').simulate('click');
+      modal.find('button').first().simulate('click');
 
       expect(props.closeModal).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the user updates and submits the form', () => {
+    it('submits an update request', () => {
+      spyOn(props, 'updateUser');
+      const modal = shallow(
+        <EditUserModal
+          updateUser={props.updateUser}
+          isOpen
+          closeModal={props.closeModal}
+          user={props.user}
+          lmsAccountId={props.lmsAccountId}
+        />
+      );
+      const nameInput = modal.find('#user_name');
+      const loginIdInput = modal.find('#user_login_id');
+      const passwordInput = modal.find('#user_password');
+      const sisUserIdInput = modal.find('#user_sis_user_id');
+      const emailInput = modal.find('#user_email');
+      const newName = 'Updated Name';
+      const newLoginId = 'Update Login Id';
+      const newPassword = 'Updated Password';
+      const newSisUserId = 'Updated SIS ID';
+      const newEmail = 'Updated Email';
+
+      expect(nameInput.prop('value')).toEqual(props.user.name);
+      expect(loginIdInput.prop('value')).toEqual(props.user.login_id);
+      expect(passwordInput.prop('value')).toEqual('');
+      expect(sisUserIdInput.prop('value')).toEqual(props.user.sis_user_id);
+      expect(emailInput.prop('value')).toEqual(props.user.email);
+
+      nameInput.simulate('change', { target: { name: 'name', value: newName } });
+      loginIdInput.simulate('change', { target: { name: 'loginId', value: newLoginId } });
+      passwordInput.simulate('change', { target: { name: 'password', value: newPassword } });
+      sisUserIdInput.simulate('change', { target: { name: 'sisUserId', value: newSisUserId } });
+      emailInput.simulate('change', { target: { name: 'email', value: newEmail } });
+
+      modal.find('button[type="submit"]').simulate('click', { preventDefault: () => {} });
+
+      expect(props.updateUser).toHaveBeenCalledWith(
+        props.lmsAccountId,
+        props.user.id,
+        props.user.login_id,
+        {
+          name: newName,
+          loginId: newLoginId,
+          password: newPassword,
+          sisUserId: newSisUserId,
+          email: newEmail,
+        },
+      );
     });
   });
 });

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -82,10 +82,10 @@ export class SearchPage extends React.Component {
           <thead>
             <tr>
               <th scope="col">Name</th>
-              <th scope="col">Email Address</th>
-              <th scope="col">Roles</th>
               <th scope="col">Login ID</th>
               <th scope="col">SIS ID</th>
+              <th scope="col">Roles</th>
+              <th scope="col">Email Address</th>
             </tr>
           </thead>
           <tbody>

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -3,6 +3,8 @@ import { shallow, mount } from 'enzyme';
 
 import { SearchPage } from './search_page';
 
+jest.mock('./edit_user_modal');
+
 describe('SearchPage', () => {
   const props = {
     searchForAccountUsers: () => {},
@@ -30,8 +32,15 @@ describe('SearchPage', () => {
     nextPageAvailable: true,
   };
 
+  const submitSearch = (searchPage) => {
+    searchPage.find('button[type="submit"]').simulate('click', {
+      preventDefault: () => {},
+      target: { form: { reportValidity: () => {} } },
+    });
+  };
+
   it('renders the search page', () => {
-    const result = shallow(<SearchPage
+    const searchPage = shallow(<SearchPage
       matchingUsers={props.matchingUsers}
       searchForAccountUsers={props.searchForAccountUsers}
       lmsAccountId={props.lmsAccountId}
@@ -40,22 +49,22 @@ describe('SearchPage', () => {
       nextPageAvailable={props.nextPageAvailable}
     />);
 
-    expect(result).toMatchSnapshot();
+    expect(searchPage).toMatchSnapshot();
   });
 
   describe('when the user submits a search', () => {
     it('submits a search request', () => {
       spyOn(props, 'searchForAccountUsers');
       const searchTerm = 'student name';
-      const result = mount(<SearchPage
+      const searchPage = shallow(<SearchPage
         matchingUsers={props.matchingUsers}
         searchForAccountUsers={props.searchForAccountUsers}
         lmsAccountId={props.lmsAccountId}
         currentPage={props.currentPage}
       />);
 
-      result.find('input').simulate('change', { target: { value: searchTerm } });
-      result.find('button[type="submit"]').simulate('click');
+      searchPage.find('input').simulate('change', { target: { value: searchTerm } });
+      submitSearch(searchPage);
 
       expect(props.searchForAccountUsers).toHaveBeenCalledWith(
         props.lmsAccountId,
@@ -67,20 +76,17 @@ describe('SearchPage', () => {
       it('does not submit the search', () => {
         spyOn(props, 'searchForAccountUsers');
         const searchTerm = 'jo';
-        const result = mount(<SearchPage
+        const searchPage = shallow(<SearchPage
           matchingUsers={props.matchingUsers}
           searchForAccountUsers={props.searchForAccountUsers}
           lmsAccountId={props.lmsAccountId}
           currentPage={props.currentPage}
         />);
 
-        result.find('input').simulate('change', { target: { value: searchTerm } });
-        result.find('button[type="submit"]').simulate('click');
+        searchPage.find('input').simulate('change', { target: { value: searchTerm } });
+        submitSearch(searchPage);
 
-        expect(props.searchForAccountUsers).not.toHaveBeenCalledWith(
-          props.lmsAccountId,
-          searchTerm,
-        );
+        expect(props.searchForAccountUsers).not.toHaveBeenCalled();
       });
     });
 
@@ -89,7 +95,7 @@ describe('SearchPage', () => {
         spyOn(props, 'searchForAccountUsers');
         const firstSearchTerm = 'john';
         const secondSearchTerm = 'jones';
-        const result = mount(<SearchPage
+        const searchPage = mount(<SearchPage
           matchingUsers={props.matchingUsers}
           searchForAccountUsers={props.searchForAccountUsers}
           lmsAccountId={props.lmsAccountId}
@@ -98,17 +104,17 @@ describe('SearchPage', () => {
           nextPageAvailable={props.nextPageAvailable}
         />);
 
-        result.find('input').simulate('change', { target: { value: firstSearchTerm } });
-        result.find('button[type="submit"]').simulate('click');
+        searchPage.find('input').simulate('change', { target: { value: firstSearchTerm } });
+        submitSearch(searchPage);
 
         expect(props.searchForAccountUsers).toHaveBeenCalledWith(
           props.lmsAccountId,
           firstSearchTerm,
         );
 
-        result.find('input').simulate('change', { target: { value: secondSearchTerm } });
+        searchPage.find('input').simulate('change', { target: { value: secondSearchTerm } });
 
-        const buttons = result.find('button');
+        const buttons = searchPage.find('button');
         const nextButton = buttons.at(buttons.length - 1);
         nextButton.simulate('click');
 

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -9,19 +9,19 @@ describe('SearchPage', () => {
     matchingUsers: [
       {
         id: 1,
-        sortable_name: 'Washington, George',
-        email: 'countryfather@revolution.com',
-        roles: ['admin', 'teacher'],
+        name: 'George Washington',
         login_id: 'countryfather@revolution.com',
         sis_user_id: 'george_123',
+        roles: ['admin', 'teacher'],
+        email: 'countryfather@revolution.com',
       },
       {
         id: 2,
-        sortable_name: 'Jefferson, Thomas',
-        email: 'idodeclare@revolution.com',
-        roles: ['teacher'],
+        name: 'Thomas Jefferson',
         login_id: 'idodeclare@revolution.com',
         sis_user_id: 'thomas_123',
+        roles: ['teacher'],
+        email: 'idodeclare@revolution.com',
       }
     ],
     lmsAccountId: '1',

--- a/client/apps/user_tool/components/main/user_search_result.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.jsx
@@ -26,13 +26,13 @@ export default class UserSearchResult extends React.Component {
         <tr>
           <td>
             <button type="button" onClick={() => this.showEditUserModal(true)}>
-              {user.sortable_name}
+              {user.name}
             </button>
           </td>
-          <td>{user.email}</td>
-          <td>{user.roles}</td>
           <td>{user.login_id}</td>
           <td>{user.sis_user_id}</td>
+          <td>{user.roles}</td>
+          <td>{user.email}</td>
         </tr>
 
         <EditUserModal

--- a/client/apps/user_tool/components/main/user_search_result.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.jsx
@@ -38,7 +38,7 @@ export default class UserSearchResult extends React.Component {
         <EditUserModal
           isOpen={editUserModalIsOpen}
           closeModal={() => this.showEditUserModal(false)}
-          userToEdit={user}
+          user={user}
         />
       </React.Fragment>
     );

--- a/client/apps/user_tool/components/main/user_search_result.spec.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.spec.jsx
@@ -5,11 +5,11 @@ import UserSearchResult from './user_search_result';
 
 describe('UserSearchResult', () => {
   const user = {
-    sortable_name: 'Washington, George',
-    email: 'countryfather@revolution.com',
-    roles: ['admin', 'teacher'],
+    name: 'George Washington',
     login_id: 'countryfather@revolution.com',
     sis_user_id: 'george_123',
+    roles: ['admin', 'teacher'],
+    email: 'countryfather@revolution.com',
   };
 
   it('renders the user as a search result', () => {

--- a/client/apps/user_tool/components/main/user_search_result.spec.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.spec.jsx
@@ -22,12 +22,12 @@ describe('UserSearchResult', () => {
     it('opens the edit user modal', () => {
       const userSearchResult = shallow(<UserSearchResult user={user} />);
 
-      let modalComponent = userSearchResult.find('EditUserModal');
+      let modalComponent = userSearchResult.find('Connect(EditUserModal)');
       expect(modalComponent.prop('isOpen')).toBe(false);
 
       userSearchResult.find('button').simulate('click');
 
-      modalComponent = userSearchResult.find('EditUserModal');
+      modalComponent = userSearchResult.find('Connect(EditUserModal)');
       expect(modalComponent.prop('isOpen')).toBe(true);
     });
   });

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -27,6 +27,32 @@ export default (state = initialState(), action) => {
       };
     }
 
+    case ApplicationConstants.UPDATE_USER_DONE: {
+      const {
+        id,
+        name,
+        login_id,
+        sis_user_id,
+        email
+      } = action.payload;
+
+      const matchingUsers = state.matchingUsers.map((user) => {
+        if (user.id === Number(id)) {
+          return {
+            ...user,
+            name,
+            login_id,
+            sis_user_id,
+            email
+          };
+        }
+
+        return user;
+      });
+
+      return { ...state, matchingUsers };
+    }
+
     default:
       return state;
   }

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -9,7 +9,7 @@ export default (state = initialState(), action) => {
     case ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS: {
       const currentPage = action.params.page || defaultPage;
 
-      return { ...state, ...{ currentPage } };
+      return { ...state, currentPage };
     }
 
     case ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE: {
@@ -19,7 +19,12 @@ export default (state = initialState(), action) => {
         next_page_available:nextPageAvailable,
       } = action.payload;
 
-      return { ...state, ...{ matchingUsers, previousPageAvailable, nextPageAvailable } };
+      return {
+        ...state,
+        matchingUsers,
+        previousPageAvailable,
+        nextPageAvailable
+      };
     }
 
     default:

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -6,9 +6,9 @@ describe('application reducer', () => {
 
   describe('initial state', () => {
     it('returns empty state', () => {
-      const state = applicationReducer(initialState, {});
+      const state = applicationReducer(initialState(), {});
 
-      expect(state).toEqual(initialState);
+      expect(state).toEqual(initialState());
     });
   });
 
@@ -20,7 +20,7 @@ describe('application reducer', () => {
         params: { page }
       };
 
-      const state = applicationReducer(initialState, action);
+      const state = applicationReducer(initialState(), action);
 
       expect(state.currentPage).toEqual(page);
     });
@@ -32,7 +32,7 @@ describe('application reducer', () => {
           params: {}
         };
 
-        const state = applicationReducer(initialState, action);
+        const state = applicationReducer(initialState(), action);
 
         expect(state.currentPage).toEqual(1);
       });
@@ -51,7 +51,7 @@ describe('application reducer', () => {
         payload: { matching_users: matchingUsers },
       };
 
-      const state = applicationReducer(initialState, action);
+      const state = applicationReducer(initialState(), action);
 
       expect(state.matchingUsers).toEqual(matchingUsers);
     });
@@ -63,7 +63,7 @@ describe('application reducer', () => {
         payload: { previous_page_available: previousPageAvailable },
       };
 
-      const state = applicationReducer(initialState, action);
+      const state = applicationReducer(initialState(), action);
 
       expect(state.previousPageAvailable).toEqual(previousPageAvailable);
     });
@@ -75,7 +75,7 @@ describe('application reducer', () => {
         payload: { next_page_available: nextPageAvailable },
       };
 
-      const state = applicationReducer(initialState, action);
+      const state = applicationReducer(initialState(), action);
 
       expect(state.nextPageAvailable).toEqual(nextPageAvailable);
     });

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -80,4 +80,47 @@ describe('application reducer', () => {
       expect(state.nextPageAvailable).toEqual(nextPageAvailable);
     });
   });
+
+  describe('UPDATE_USER_DONE', () => {
+    it('updates the user in matchingUsers', () => {
+      const matchingUsers = [
+        {
+          id: 1,
+          name: 'George Washington',
+          login_id: 'countryfather@revolution.com',
+          sis_user_id: 'george_123',
+          email: 'countryfather@revolution.com',
+        },
+        {
+          id: 2,
+          name: 'John Adams',
+          login_id: 'adamsforindependence@greatbritain.com',
+          sis_user_id: 'john_123',
+          email: 'adamsforindependence@greatbritain.com',
+        },
+        {
+          id: 3,
+          name: 'Thomas Jefferson',
+          login_id: 'idodeclare@revolution.com',
+          sis_user_id: 'thomas_123',
+          email: 'idodeclare@revolution.com',
+        },
+      ];
+      const updatedUser = {
+        id: 2,
+        name: 'John Adams',
+        login_id: 'adamsforindependence@revolution.com',
+        sis_user_id: 'john_123',
+        email: 'adamsforindependence@revolution.com'
+      };
+      const action = {
+        type: ApplicationConstants.UPDATE_USER_DONE,
+        payload: updatedUser,
+      };
+
+      const state = applicationReducer({ ...initialState(), matchingUsers }, action);
+
+      expect(state.matchingUsers[1]).toEqual(updatedUser);
+    });
+  });
 });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
     post "proctor_conversations" => "proctor_conversations#initiate_conversation"
     resources :jwts
     resources :canvas_accounts do
-      resources :canvas_users, only: [:index]
+      resources :canvas_users, only: [:index, :update]
     end
     resources :oauths
     resources :courses, only: [] do

--- a/spec/controllers/api/canvas_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_users_controller_spec.rb
@@ -160,5 +160,26 @@ RSpec.describe Api::CanvasUsersController, type: :controller do
 
       expect(JSON.parse(response.body)["email"]).to eq(params[:user][:email])
     end
+
+    context "when the user is not in the admin's account or sub-account" do
+      before do
+        allow_any_instance_of(LMS::Canvas).to receive(:api_get_request).
+          with(a_string_including("accounts/#{params[:canvas_account_id]}/users")).
+          and_return(OpenStruct.new({ parsed_response: [] }))
+      end
+
+      it "returns a 401 unauthorized" do
+        response = put(:update, params: params)
+
+        expect(response.status).to eq(401)
+      end
+
+      it "returns an error message" do
+        response = put(:update, format: :json, params: params)
+
+        expect(JSON.parse(response.body)["message"]).
+          to match(/modify users from the account/i)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171524491](https://www.pivotaltracker.com/story/show/171524491), [#171525027](https://www.pivotaltracker.com/story/show/171525027)

This adds a modal and form that allows an admin to update the following information for a user:
- Name
- Login ID
- Password 
- SIS ID
- Email

## Implementation
For a couple of the API calls to Canvas, I used `canvas_api.api_put_request` instead of `canvas_api.proxy`. I generally prefer using `proxy`, but it wasn't working for those 2 API calls for whatever reason. I'd like to figure out what the issues were, but I didn't want to let it hold up adding this code.

## Things to Look Out for While Reviewing
When we update the name, the sortable name is updated automatically, but the display name (AKA short name) is not. Should we update the display name too?

With this implementation, when we update the student email, it actually just adds a new email to their account and makes it their primary email. It doesn't remove their old one. I think this is fine.
It also doesn't confirm the email. This also makes sense to me.
Does anyone have objections to how this implementation handles emails?

The `update` action issues 3 separate requests to the Canvas API. Not terrible, but not great. If anyone knows of a way to reduce this number, I'd appreciate suggestions.

## Demo
![update_student](https://user-images.githubusercontent.com/6520489/77692452-3a17a280-6f6c-11ea-8d09-984793cdf471.gif)

(This demo doesn't show updating the password because I didn't see an easy way to actually show that working; I did test changing a password though and verified that it does work.)