### PR TITLE
Add No Results Components

### DIFF
--- a/client/apps/user_tool/components/main/__snapshots__/no_search_results.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/no_search_results.spec.jsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoSearchResults renders the no search results section 1`] = `
+<section>
+  <p>
+    Your search - 
+    <strong>
+      some search
+    </strong>
+     - did not match any users.
+  </p>
+  <p>
+    Suggestions:
+  </p>
+  <ul>
+    <li>
+      Double check your spelling.
+    </li>
+    <li>
+      Try more general keywords.
+    </li>
+    <li>
+      Try different keywords.
+    </li>
+  </ul>
+</section>
+`;

--- a/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
@@ -81,6 +81,7 @@ exports[`SearchPage renders the search page 1`] = `
       />
     </tbody>
   </table>
+  <StartSearching />
   <Pagination
     changePageTo={[Function]}
     currentPage={2}

--- a/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
@@ -17,9 +17,6 @@ exports[`SearchPage renders the search page 1`] = `
       Search
     </button>
   </form>
-  <p>
-    Search Results:
-  </p>
   <table>
     <thead>
       <tr>

--- a/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/search_page.spec.jsx.snap
@@ -90,3 +90,64 @@ exports[`SearchPage renders the search page 1`] = `
   />
 </div>
 `;
+
+exports[`SearchPage when the user submits a search that returns no results displays the no search results section 1`] = `
+<div>
+  <form>
+    <input
+      minLength={3}
+      onChange={[Function]}
+      placeholder="Search for students..."
+      type="search"
+      value="student name"
+    />
+    <button
+      onClick={[Function]}
+      type="submit"
+    >
+      Search
+    </button>
+  </form>
+  <table>
+    <thead>
+      <tr>
+        <th
+          scope="col"
+        >
+          Name
+        </th>
+        <th
+          scope="col"
+        >
+          Login ID
+        </th>
+        <th
+          scope="col"
+        >
+          SIS ID
+        </th>
+        <th
+          scope="col"
+        >
+          Roles
+        </th>
+        <th
+          scope="col"
+        >
+          Email Address
+        </th>
+      </tr>
+    </thead>
+    <tbody />
+  </table>
+  <NoSearchResults
+    searchTerm="student name"
+  />
+  <Pagination
+    changePageTo={[Function]}
+    currentPage={2}
+    nextPageAvailable={true}
+    previousPageAvailable={true}
+  />
+</div>
+`;

--- a/client/apps/user_tool/components/main/no_search_results.jsx
+++ b/client/apps/user_tool/components/main/no_search_results.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class NoSearchResults extends React.Component {
+  static propTypes = {
+    searchTerm: PropTypes.string.isRequired,
+  };
+
+  render() {
+    const { searchTerm } = this.props;
+
+    return (
+      <section>
+        <p>
+          Your search - <strong>{searchTerm}</strong> - did not match any users.
+        </p>
+        <p>Suggestions:</p>
+        <ul>
+          <li>Double check your spelling.</li>
+          <li>Try more general keywords.</li>
+          <li>Try different keywords.</li>
+        </ul>
+      </section>
+    );
+  }
+}

--- a/client/apps/user_tool/components/main/no_search_results.spec.jsx
+++ b/client/apps/user_tool/components/main/no_search_results.spec.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import NoSearchResults from './no_search_results';
+
+describe('NoSearchResults', () => {
+  it('renders the no search results section', () => {
+    const result = shallow(<NoSearchResults searchTerm="some search" />);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -77,7 +77,6 @@ export class SearchPage extends React.Component {
           />
           <button type="submit" onClick={event => this.handleSearch(event)}>Search</button>
         </form>
-        <p>Search Results:</p>
         <table>
           <thead>
             <tr>

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -44,9 +44,9 @@ export class SearchPage extends React.Component {
     const { lmsAccountId, searchForAccountUsers:search } = this.props;
     const { inputSearchTerm } = this.state;
 
-    this.setState({ resultsSearchTerm: inputSearchTerm });
-
     if (inputSearchTerm.length >= this.minSearchTermLength) {
+      this.setState({ resultsSearchTerm: inputSearchTerm
+
       search(lmsAccountId, inputSearchTerm);
     }
   }

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import _ from 'lodash';
+
 import { searchForAccountUsers } from '../../actions/application';
 import UserSearchResult from './user_search_result';
 import StartSearching from './start_searching';
+import NoSearchResults from './no_search_results';
 import Pagination from '../../../../common/components/common/pagination';
 
 const select = state => ({
@@ -47,7 +50,7 @@ export class SearchPage extends React.Component {
     const { inputSearchTerm } = this.state;
 
     if (inputSearchTerm.length >= this.minSearchTermLength) {
-      this.setState({ resultsSearchTerm: inputSearchTerm
+      this.setState({ resultsSearchTerm: inputSearchTerm, hasSearched: true });
 
       search(lmsAccountId, inputSearchTerm);
     }
@@ -95,6 +98,12 @@ export class SearchPage extends React.Component {
         </table>
 
         { !hasSearched && <StartSearching /> }
+
+        {
+          hasSearched
+          && _.isEmpty(matchingUsers)
+          && <NoSearchResults searchTerm={resultsSearchTerm} />
+        }
 
         <Pagination
           changePageTo={page => search(lmsAccountId, resultsSearchTerm, page)}

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { searchForAccountUsers } from '../../actions/application';
 import UserSearchResult from './user_search_result';
+import StartSearching from './start_searching';
 import Pagination from '../../../../common/components/common/pagination';
 
 const select = state => ({
@@ -29,6 +30,7 @@ export class SearchPage extends React.Component {
     this.state = {
       inputSearchTerm: '', // The search term currently in the input field.
       resultsSearchTerm: '', // The search term associated with the currently displayed results.
+      hasSearched: false,
     };
     this.minSearchTermLength = 3;
   }
@@ -60,7 +62,7 @@ export class SearchPage extends React.Component {
       previousPageAvailable,
       nextPageAvailable
     } = this.props;
-    const { inputSearchTerm, resultsSearchTerm } = this.state;
+    const { inputSearchTerm, resultsSearchTerm, hasSearched } = this.state;
     const renderedUsers = matchingUsers.map(user => (
       <UserSearchResult key={user.id} user={user} />
     ));
@@ -91,6 +93,9 @@ export class SearchPage extends React.Component {
             {renderedUsers}
           </tbody>
         </table>
+
+        { !hasSearched && <StartSearching /> }
+
         <Pagination
           changePageTo={page => search(lmsAccountId, resultsSearchTerm, page)}
           currentPage={currentPage}

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -73,6 +73,24 @@ describe('SearchPage', () => {
     });
   });
 
+  describe('when the user submits a search that returns no results', () => {
+    it('displays the no search results section', () => {
+      const searchPage = shallow(<SearchPage
+        matchingUsers={[]}
+        searchForAccountUsers={props.searchForAccountUsers}
+        lmsAccountId={props.lmsAccountId}
+        currentPage={props.currentPage}
+        previousPageAvailable={props.previousPageAvailable}
+        nextPageAvailable={props.nextPageAvailable}
+      />);
+
+      searchPage.find('input').simulate('change', { target: { value: 'student name' } });
+      submitSearch(searchPage);
+
+      expect(searchPage).toMatchSnapshot();
+    });
+  });
+
   describe('when the user submits a search with less than 3 characters', () => {
     it('does not submit the search', () => {
       spyOn(props, 'searchForAccountUsers');

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -71,94 +71,94 @@ describe('SearchPage', () => {
         searchTerm,
       );
     });
+  });
 
-    describe('when the user submits a search with less than 3 characters', () => {
-      it('does not submit the search', () => {
-        spyOn(props, 'searchForAccountUsers');
-        const searchTerm = 'jo';
-        const searchPage = shallow(<SearchPage
-          matchingUsers={props.matchingUsers}
-          searchForAccountUsers={props.searchForAccountUsers}
-          lmsAccountId={props.lmsAccountId}
-          currentPage={props.currentPage}
-        />);
+  describe('when the user submits a search with less than 3 characters', () => {
+    it('does not submit the search', () => {
+      spyOn(props, 'searchForAccountUsers');
+      const searchTerm = 'jo';
+      const searchPage = shallow(<SearchPage
+        matchingUsers={props.matchingUsers}
+        searchForAccountUsers={props.searchForAccountUsers}
+        lmsAccountId={props.lmsAccountId}
+        currentPage={props.currentPage}
+      />);
 
-        searchPage.find('input').simulate('change', { target: { value: searchTerm } });
-        submitSearch(searchPage);
+      searchPage.find('input').simulate('change', { target: { value: searchTerm } });
+      submitSearch(searchPage);
 
-        expect(props.searchForAccountUsers).not.toHaveBeenCalled();
-      });
-
-      it('does not affect the paged results', () => {
-        spyOn(props, 'searchForAccountUsers');
-        const firstSearchTerm = 'john';
-        const shortSearchTerm = 'sa';
-        const searchPage = mount(<SearchPage
-          matchingUsers={props.matchingUsers}
-          searchForAccountUsers={props.searchForAccountUsers}
-          lmsAccountId={props.lmsAccountId}
-          currentPage={props.currentPage}
-          previousPageAvailable={props.previousPageAvailable}
-          nextPageAvailable={props.nextPageAvailable}
-        />);
-
-        searchPage.find('input').simulate('change', { target: { value: firstSearchTerm } });
-        submitSearch(searchPage);
-
-        expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-          props.lmsAccountId,
-          firstSearchTerm,
-        );
-
-        searchPage.find('input').simulate('change', { target: { value: shortSearchTerm } });
-        submitSearch(searchPage);
-
-        const buttons = searchPage.find('button');
-        const nextButton = buttons.at(buttons.length - 1);
-        nextButton.simulate('click');
-
-        expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-          props.lmsAccountId,
-          firstSearchTerm,
-          props.currentPage + 1,
-        );
-      });
+      expect(props.searchForAccountUsers).not.toHaveBeenCalled();
     });
 
-    describe('when the user updates the value in the search input field', () => {
-      it('does not affect the paged results', () => {
-        spyOn(props, 'searchForAccountUsers');
-        const firstSearchTerm = 'john';
-        const secondSearchTerm = 'jones';
-        const searchPage = mount(<SearchPage
-          matchingUsers={props.matchingUsers}
-          searchForAccountUsers={props.searchForAccountUsers}
-          lmsAccountId={props.lmsAccountId}
-          currentPage={props.currentPage}
-          previousPageAvailable={props.previousPageAvailable}
-          nextPageAvailable={props.nextPageAvailable}
-        />);
+    it('does not affect the paged results', () => {
+      spyOn(props, 'searchForAccountUsers');
+      const firstSearchTerm = 'john';
+      const shortSearchTerm = 'sa';
+      const searchPage = mount(<SearchPage
+        matchingUsers={props.matchingUsers}
+        searchForAccountUsers={props.searchForAccountUsers}
+        lmsAccountId={props.lmsAccountId}
+        currentPage={props.currentPage}
+        previousPageAvailable={props.previousPageAvailable}
+        nextPageAvailable={props.nextPageAvailable}
+      />);
 
-        searchPage.find('input').simulate('change', { target: { value: firstSearchTerm } });
-        submitSearch(searchPage);
+      searchPage.find('input').simulate('change', { target: { value: firstSearchTerm } });
+      submitSearch(searchPage);
 
-        expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-          props.lmsAccountId,
-          firstSearchTerm,
-        );
+      expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+        props.lmsAccountId,
+        firstSearchTerm,
+      );
 
-        searchPage.find('input').simulate('change', { target: { value: secondSearchTerm } });
+      searchPage.find('input').simulate('change', { target: { value: shortSearchTerm } });
+      submitSearch(searchPage);
 
-        const buttons = searchPage.find('button');
-        const nextButton = buttons.at(buttons.length - 1);
-        nextButton.simulate('click');
+      const buttons = searchPage.find('button');
+      const nextButton = buttons.at(buttons.length - 1);
+      nextButton.simulate('click');
 
-        expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-          props.lmsAccountId,
-          firstSearchTerm,
-          props.currentPage + 1,
-        );
-      });
+      expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+        props.lmsAccountId,
+        firstSearchTerm,
+        props.currentPage + 1,
+      );
+    });
+  });
+
+  describe('when the user updates the value in the search input field', () => {
+    it('does not affect the paged results', () => {
+      spyOn(props, 'searchForAccountUsers');
+      const firstSearchTerm = 'john';
+      const secondSearchTerm = 'jones';
+      const searchPage = mount(<SearchPage
+        matchingUsers={props.matchingUsers}
+        searchForAccountUsers={props.searchForAccountUsers}
+        lmsAccountId={props.lmsAccountId}
+        currentPage={props.currentPage}
+        previousPageAvailable={props.previousPageAvailable}
+        nextPageAvailable={props.nextPageAvailable}
+      />);
+
+      searchPage.find('input').simulate('change', { target: { value: firstSearchTerm } });
+      submitSearch(searchPage);
+
+      expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+        props.lmsAccountId,
+        firstSearchTerm,
+      );
+
+      searchPage.find('input').simulate('change', { target: { value: secondSearchTerm } });
+
+      const buttons = searchPage.find('button');
+      const nextButton = buttons.at(buttons.length - 1);
+      nextButton.simulate('click');
+
+      expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+        props.lmsAccountId,
+        firstSearchTerm,
+        props.currentPage + 1,
+      );
     });
   });
 });

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -88,6 +88,41 @@ describe('SearchPage', () => {
 
         expect(props.searchForAccountUsers).not.toHaveBeenCalled();
       });
+
+      it('does not affect the paged results', () => {
+        spyOn(props, 'searchForAccountUsers');
+        const firstSearchTerm = 'john';
+        const shortSearchTerm = 'sa';
+        const searchPage = mount(<SearchPage
+          matchingUsers={props.matchingUsers}
+          searchForAccountUsers={props.searchForAccountUsers}
+          lmsAccountId={props.lmsAccountId}
+          currentPage={props.currentPage}
+          previousPageAvailable={props.previousPageAvailable}
+          nextPageAvailable={props.nextPageAvailable}
+        />);
+
+        searchPage.find('input').simulate('change', { target: { value: firstSearchTerm } });
+        submitSearch(searchPage);
+
+        expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+          props.lmsAccountId,
+          firstSearchTerm,
+        );
+
+        searchPage.find('input').simulate('change', { target: { value: shortSearchTerm } });
+        submitSearch(searchPage);
+
+        const buttons = searchPage.find('button');
+        const nextButton = buttons.at(buttons.length - 1);
+        nextButton.simulate('click');
+
+        expect(props.searchForAccountUsers).toHaveBeenCalledWith(
+          props.lmsAccountId,
+          firstSearchTerm,
+          props.currentPage + 1,
+        );
+      });
     });
 
     describe('when the user updates the value in the search input field', () => {

--- a/client/apps/user_tool/components/main/start_searching.jsx
+++ b/client/apps/user_tool/components/main/start_searching.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default class StartSearching extends React.Component {
+  render() {
+    return (
+      <section>
+        <p>
+          Search for a user by: Name, Login ID, SIS ID, or Email.
+        </p>
+      </section>
+    );
+  }
+}


### PR DESCRIPTION
Pivotal Tracker: [#171942592](https://www.pivotaltracker.com/story/show/171942592)

This branch adds a couple of components to match [Brandon's designs](https://xd.adobe.com/view/fc7bb54f-3fa8-4a42-7f0d-160d08c990b3-8a4a/grid).

One component is displayed when the user first loads the application:
![start_searching](https://user-images.githubusercontent.com/6520489/77802582-ceebd000-7040-11ea-9cfd-df0132b4d3ef.png)

The other component is displayed when the user performs a search that returns no results:
![no_results](https://user-images.githubusercontent.com/6520489/77802592-d27f5700-7040-11ea-9028-a9a7b8ce16fa.png)