### PR TITLE
Prevent Admins From Listing and Updating Users Outside Their Account

### DIFF
--- a/app/controllers/concerns/jwt_token.rb
+++ b/app/controllers/concerns/jwt_token.rb
@@ -81,6 +81,11 @@ module Concerns
       token["lms_course_id"]
     end
 
+    def jwt_lms_account_id
+      token = decoded_jwt_token(request)
+      token["lms_account_id"]
+    end
+
     def jwt_lti_roles_string
       jwt_lti_roles.join(",")
     end

--- a/app/helpers/jwt_helper.rb
+++ b/app/helpers/jwt_helper.rb
@@ -22,6 +22,7 @@ module JwtHelper
       attrs[:tool_consumer_instance_guid] = params[:tool_consumer_instance_guid]
       attrs[:context_id] = params[:context_id]
       attrs[:lms_course_id] = params[:custom_canvas_course_id]
+      attrs[:lms_account_id] = params[:custom_canvas_account_id]
       attrs[:kid] = params[:oauth_consumer_key]
     end
 

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -9,17 +9,17 @@ const requests = ['SEARCH_FOR_ACCOUNT_USERS', 'UPDATE_USER'];
 
 export const Constants = wrapper(actions, requests);
 
-export const searchForAccountUsers = (lmsAccountId, searchTerm, page) => ({
+export const searchForAccountUsers = (searchTerm, page) => ({
   type: Constants.SEARCH_FOR_ACCOUNT_USERS,
   method: Network.GET,
-  url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
+  url: 'api/canvas_account_users',
   params: {
     search_term: searchTerm,
     page,
   },
 });
 
-export const updateUser = (lmsAccountId, userId, originalUserLoginId, userAttributes) => {
+export const updateUser = (userId, originalUserLoginId, userAttributes) => {
   const body = {
     original_user_login_id: originalUserLoginId,
     user: {
@@ -37,7 +37,7 @@ export const updateUser = (lmsAccountId, userId, originalUserLoginId, userAttrib
   return {
     type: Constants.UPDATE_USER,
     method: Network.PUT,
-    url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
+    url: `api/canvas_account_users/${userId}`,
     body,
   };
 };

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -3,44 +3,41 @@ import { searchForAccountUsers, updateUser } from './application';
 describe('application actions', () => {
   describe('searchForAccountUsers', () => {
     it('generates the correct action', () => {
-      const lmsAccountId = 123;
       const searchTerm = 'student name';
       const page = '2';
       const expectedAction = {
         type: 'SEARCH_FOR_ACCOUNT_USERS',
         method: 'get',
-        url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
+        url: 'api/canvas_account_users',
         params: {
           search_term: searchTerm,
           page,
         },
       };
 
-      expect(searchForAccountUsers(lmsAccountId, searchTerm, page)).toEqual(expectedAction);
+      expect(searchForAccountUsers(searchTerm, page)).toEqual(expectedAction);
     });
 
     describe('when no search term is given', () => {
       it('generates the correct action', () => {
-        const lmsAccountId = 123;
         const searchTerm = '';
         const page = '2';
         const expectedAction = {
           type: 'SEARCH_FOR_ACCOUNT_USERS',
           method: 'get',
-          url: `api/canvas_accounts/${lmsAccountId}/canvas_users`,
+          url: 'api/canvas_account_users',
           params: {
             search_term: searchTerm,
             page,
           },
         };
 
-        expect(searchForAccountUsers(lmsAccountId, searchTerm, page)).toEqual(expectedAction);
+        expect(searchForAccountUsers(searchTerm, page)).toEqual(expectedAction);
       });
     });
   });
 
   describe('updateUser', () => {
-    const lmsAccountId = 123;
     const userId = 45;
     const originalUserLoginId = 'adamsforindepence@greatbritain.com';
     const userAttributes = {
@@ -55,7 +52,7 @@ describe('application actions', () => {
       const expectedAction = {
         type: 'UPDATE_USER',
         method: 'put',
-        url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
+        url: `api/canvas_account_users/${userId}`,
         body: {
           original_user_login_id: originalUserLoginId,
           user: {
@@ -68,7 +65,7 @@ describe('application actions', () => {
         }
       };
 
-      expect(updateUser(lmsAccountId, userId, originalUserLoginId, userAttributes))
+      expect(updateUser(userId, originalUserLoginId, userAttributes))
         .toEqual(expectedAction);
     });
 
@@ -79,7 +76,7 @@ describe('application actions', () => {
         const expectedAction = {
           type: 'UPDATE_USER',
           method: 'put',
-          url: `api/canvas_accounts/${lmsAccountId}/canvas_users/${userId}`,
+          url: `api/canvas_account_users/${userId}`,
           body: {
             original_user_login_id: originalUserLoginId,
             user: {
@@ -91,7 +88,7 @@ describe('application actions', () => {
           }
         };
 
-        expect(updateUser(lmsAccountId, userId, originalUserLoginId, userAttributes))
+        expect(updateUser(userId, originalUserLoginId, userAttributes))
           .toEqual(expectedAction);
       });
     });

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -4,9 +4,7 @@ import ReactModal from 'react-modal';
 import { connect } from 'react-redux';
 import { updateUser } from '../../actions/application';
 
-const select = state => ({
-  lmsAccountId: state.settings.custom_canvas_account_id,
-});
+const select = () => ({});
 
 export class EditUserModal extends React.Component {
   static propTypes = {
@@ -14,7 +12,6 @@ export class EditUserModal extends React.Component {
     isOpen: PropTypes.bool.isRequired,
     closeModal: PropTypes.func.isRequired,
     user: PropTypes.object.isRequired,
-    lmsAccountId: PropTypes.string.isRequired,
   };
 
   constructor(props) {
@@ -51,14 +48,13 @@ export class EditUserModal extends React.Component {
     event.preventDefault();
 
     const {
-      lmsAccountId,
       user,
       updateUser:update,
       closeModal
     } = this.props;
     const { userForm } = this.state;
 
-    update(lmsAccountId, user.id, user.login_id, userForm);
+    update(user.id, user.login_id, userForm);
 
     closeModal();
   }

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -14,7 +14,6 @@ describe('EditUserModal', () => {
       login_id: 'countryfather@revolution.com',
       sis_user_id: 'george_123',
     },
-    lmsAccountId: '1',
   };
 
   it('renders the edit user modal', () => {
@@ -24,7 +23,6 @@ describe('EditUserModal', () => {
         isOpen
         closeModal={props.closeModal}
         user={props.user}
-        lmsAccountId={props.lmsAccountId}
       />
     );
 
@@ -40,7 +38,6 @@ describe('EditUserModal', () => {
           isOpen
           closeModal={props.closeModal}
           user={props.user}
-          lmsAccountId={props.lmsAccountId}
         />
       );
 
@@ -59,7 +56,6 @@ describe('EditUserModal', () => {
           isOpen
           closeModal={props.closeModal}
           user={props.user}
-          lmsAccountId={props.lmsAccountId}
         />
       );
       const nameInput = modal.find('#user_name');
@@ -88,7 +84,6 @@ describe('EditUserModal', () => {
       modal.find('button[type="submit"]').simulate('click', { preventDefault: () => {} });
 
       expect(props.updateUser).toHaveBeenCalledWith(
-        props.lmsAccountId,
         props.user.id,
         props.user.login_id,
         {

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -11,7 +11,6 @@ import Pagination from '../../../../common/components/common/pagination';
 
 const select = state => ({
   matchingUsers: state.application.matchingUsers,
-  lmsAccountId: state.settings.custom_canvas_account_id,
   currentPage: state.application.currentPage,
   previousPageAvailable: state.application.previousPageAvailable,
   nextPageAvailable: state.application.nextPageAvailable,
@@ -21,7 +20,6 @@ export class SearchPage extends React.Component {
   static propTypes = {
     searchForAccountUsers: PropTypes.func.isRequired,
     matchingUsers: PropTypes.array.isRequired,
-    lmsAccountId: PropTypes.string.isRequired,
     currentPage: PropTypes.number.isRequired,
     previousPageAvailable: PropTypes.bool,
     nextPageAvailable: PropTypes.bool,
@@ -46,20 +44,19 @@ export class SearchPage extends React.Component {
     event.preventDefault();
     event.target.form.reportValidity();
 
-    const { lmsAccountId, searchForAccountUsers:search } = this.props;
+    const { searchForAccountUsers:search } = this.props;
     const { inputSearchTerm } = this.state;
 
     if (inputSearchTerm.length >= this.minSearchTermLength) {
       this.setState({ resultsSearchTerm: inputSearchTerm, hasSearched: true });
 
-      search(lmsAccountId, inputSearchTerm);
+      search(inputSearchTerm);
     }
   }
 
   render() {
     const {
       searchForAccountUsers:search,
-      lmsAccountId,
       matchingUsers,
       currentPage,
       previousPageAvailable,
@@ -106,7 +103,7 @@ export class SearchPage extends React.Component {
         }
 
         <Pagination
-          changePageTo={page => search(lmsAccountId, resultsSearchTerm, page)}
+          changePageTo={page => search(resultsSearchTerm, page)}
           currentPage={currentPage}
           previousPageAvailable={previousPageAvailable}
           nextPageAvailable={nextPageAvailable}

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -26,7 +26,6 @@ describe('SearchPage', () => {
         email: 'idodeclare@revolution.com',
       }
     ],
-    lmsAccountId: '1',
     currentPage: 2,
     previousPageAvailable: true,
     nextPageAvailable: true,
@@ -43,7 +42,6 @@ describe('SearchPage', () => {
     const searchPage = shallow(<SearchPage
       matchingUsers={props.matchingUsers}
       searchForAccountUsers={props.searchForAccountUsers}
-      lmsAccountId={props.lmsAccountId}
       currentPage={props.currentPage}
       previousPageAvailable={props.previousPageAvailable}
       nextPageAvailable={props.nextPageAvailable}
@@ -59,7 +57,6 @@ describe('SearchPage', () => {
       const searchPage = shallow(<SearchPage
         matchingUsers={props.matchingUsers}
         searchForAccountUsers={props.searchForAccountUsers}
-        lmsAccountId={props.lmsAccountId}
         currentPage={props.currentPage}
       />);
 
@@ -67,7 +64,6 @@ describe('SearchPage', () => {
       submitSearch(searchPage);
 
       expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-        props.lmsAccountId,
         searchTerm,
       );
     });
@@ -78,7 +74,6 @@ describe('SearchPage', () => {
       const searchPage = shallow(<SearchPage
         matchingUsers={[]}
         searchForAccountUsers={props.searchForAccountUsers}
-        lmsAccountId={props.lmsAccountId}
         currentPage={props.currentPage}
         previousPageAvailable={props.previousPageAvailable}
         nextPageAvailable={props.nextPageAvailable}
@@ -98,7 +93,6 @@ describe('SearchPage', () => {
       const searchPage = shallow(<SearchPage
         matchingUsers={props.matchingUsers}
         searchForAccountUsers={props.searchForAccountUsers}
-        lmsAccountId={props.lmsAccountId}
         currentPage={props.currentPage}
       />);
 
@@ -115,7 +109,6 @@ describe('SearchPage', () => {
       const searchPage = mount(<SearchPage
         matchingUsers={props.matchingUsers}
         searchForAccountUsers={props.searchForAccountUsers}
-        lmsAccountId={props.lmsAccountId}
         currentPage={props.currentPage}
         previousPageAvailable={props.previousPageAvailable}
         nextPageAvailable={props.nextPageAvailable}
@@ -125,7 +118,6 @@ describe('SearchPage', () => {
       submitSearch(searchPage);
 
       expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-        props.lmsAccountId,
         firstSearchTerm,
       );
 
@@ -137,7 +129,6 @@ describe('SearchPage', () => {
       nextButton.simulate('click');
 
       expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-        props.lmsAccountId,
         firstSearchTerm,
         props.currentPage + 1,
       );
@@ -152,7 +143,6 @@ describe('SearchPage', () => {
       const searchPage = mount(<SearchPage
         matchingUsers={props.matchingUsers}
         searchForAccountUsers={props.searchForAccountUsers}
-        lmsAccountId={props.lmsAccountId}
         currentPage={props.currentPage}
         previousPageAvailable={props.previousPageAvailable}
         nextPageAvailable={props.nextPageAvailable}
@@ -162,7 +152,6 @@ describe('SearchPage', () => {
       submitSearch(searchPage);
 
       expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-        props.lmsAccountId,
         firstSearchTerm,
       );
 
@@ -173,7 +162,6 @@ describe('SearchPage', () => {
       nextButton.simulate('click');
 
       expect(props.searchForAccountUsers).toHaveBeenCalledWith(
-        props.lmsAccountId,
         firstSearchTerm,
         props.currentPage + 1,
       );

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,9 +62,6 @@ Rails.application.routes.draw do
     resources :proctored_exams, only: [:update]
     post "proctor_conversations" => "proctor_conversations#initiate_conversation"
     resources :jwts
-    resources :canvas_accounts do
-      resources :canvas_users, only: [:index, :update]
-    end
     resources :oauths
     resources :courses, only: [] do
       resources :students, only: [:index]
@@ -82,6 +79,8 @@ Rails.application.routes.draw do
     end
 
     resources :canvas_accounts, only: [:index]
+    # This endpoint provides access to users belonging to the Canvas account associated with the LTI launch.
+    resources :canvas_account_users, only: [:index, :update]
 
     resources :testing_centers_accounts
     resources :scorm_courses do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -412,6 +412,7 @@ applications = [
       privacy_level: "public",
       icon: "oauth_icon.png",
       custom_fields: {
+        canvas_account_id: "$Canvas.account.id",
         external_tool_url: "$Canvas.externalTool.url",
       },
       account_navigation: {

--- a/spec/controllers/concerns/jwt_token_spec.rb
+++ b/spec/controllers/concerns/jwt_token_spec.rb
@@ -104,4 +104,15 @@ describe ApplicationController, type: :controller do
       expect(controller.lti_admin?).to eq(true)
     end
   end
+
+  describe "jwt_lms_account_id" do
+    it "returns the lms_account_id" do
+      lms_account_id = "739"
+      token = AuthToken.issue_token({ lms_account_id: lms_account_id })
+
+      request.headers["Authorization"] = "Bearer #{token}"
+
+      expect(controller.jwt_lms_account_id).to eq(lms_account_id)
+    end
+  end
 end


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#172031298](https://www.pivotaltracker.com/story/show/172031298)

Previously, the client specified which Canvas account they wanted to operate within by passing the ID of the account in the url. e.g. `/canvas_accounts/123/canvas_users`. Allowing the client to specify which Canvas account they want to use creates a security risk though; someone could manually create a request to the back-end and access accounts they wouldn't otherwise have permission to access.

To ensure admins are only accessing users they have permissions to access, we're using the Canvas account ID we get in the LTI launch instead.

## Implementation
I added additional code to store the Canvas account ID in the JWT during the LTI launch.

## Tradeoffs & Alternatives
I renamed the `canvas_accounts/:account_id/canvas_users` endpoint to `canvas_account_users`. To me, `canvas_account_users` seems like kind of an odd name. I considered using `canvas_users` but that, to me, seems to suggest that the request will operate on all Canvas users, not just the users in a certain account. I also considered just keeping the `canvas_accounts/:account_id/canvas_users` route, but that doesn't seem to make much sense if we're not actually letting them specify the Canvas account to operate on. So I went with `canvas_account_users` because I think it's the clearest of the options I considered even though it seems like an odd name.