### PR TITLE
Improve Password Input Label

### DIFF
--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -57,7 +57,7 @@ exports[`EditUserModal renders the edit user modal 1`] = `
     <label
       htmlFor="user_password"
     >
-      Password
+      New Password
       <input
         id="user_password"
         name="password"

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -102,7 +102,7 @@ export class EditUserModal extends React.Component {
           </label>
 
           <label htmlFor="user_password">
-            Password
+            New Password
             <input
               id="user_password"
               name="password"


### PR DESCRIPTION
Pivotal Tracker: [#172228616](https://www.pivotaltracker.com/story/show/172228616)

Currently, the password field in the edit user form is labeled with "Password". Brandon suggested "New Password" would be better because it doesn't display the old password; it's just a field to change it.