### PR TITLE
Was: overflow fix

### DIFF
--- a/client/apps/user_tool/styles/partials/_inputs.scss
+++ b/client/apps/user_tool/styles/partials/_inputs.scss
@@ -113,6 +113,14 @@
     @include regular;
     color: $blue;
     margin-top: 0.2rem;
+
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    /* Adds a hyphen where the word breaks, if supported (No Blink) */
+    -ms-hyphens: auto;
+    -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    hyphens: auto;
   }
 }
 


### PR DESCRIPTION
This should break any long words, emails, etc before they overflow their container.