### PR TITLE
Log Changes to User Data

### DIFF
--- a/app/controllers/api/canvas_account_users_controller.rb
+++ b/app/controllers/api/canvas_account_users_controller.rb
@@ -62,7 +62,9 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
   end
 
   def fetch_original_user
-    @original_user = search_for_users_on_canvas(params[:id]).first
+    original_user = search_for_users_on_canvas(params[:id]).first
+
+    @original_user = HashWithIndifferentAccess.new(original_user)
   end
 
   def validate_user_is_in_account

--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -35,8 +35,8 @@ class CanvasUserChange < ApplicationRecord
     create!(record_attrs)
   end
 
-  def has_failed_attributes?
+  def failed_attributes?
     failed_attributes.present?
   end
-  alias_method :has_failed_attrs?, :has_failed_attributes?
+  alias_method :failed_attrs?, :failed_attributes?
 end

--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -11,6 +11,7 @@ class CanvasUserChange < ApplicationRecord
     record_attrs = {
       admin_making_changes_lms_id: admin_making_changes_lms_id,
       user_being_changed_lms_id: user_being_changed_lms_id,
+      failed_attributes: failed_attrs,
     }
 
     [:name, :login_id, :sis_user_id, :email].each do |attr|

--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -34,4 +34,9 @@ class CanvasUserChange < ApplicationRecord
 
     create!(record_attrs)
   end
+
+  def has_failed_attributes?
+    failed_attributes.present?
+  end
+  alias_method :has_failed_attrs?, :has_failed_attributes?
 end

--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -1,7 +1,7 @@
 class CanvasUserChange < ApplicationRecord
   validates :admin_making_changes_lms_id, :user_being_changed_lms_id, presence: true
 
-  def self.create_by_diffing_attrs(
+  def self.create_by_diffing_attrs!(
     admin_making_changes_lms_id:,
     user_being_changed_lms_id:,
     original_attrs:,
@@ -31,6 +31,6 @@ class CanvasUserChange < ApplicationRecord
       }
     end
 
-    create(record_attrs)
+    create!(record_attrs)
   end
 end

--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -1,3 +1,36 @@
 class CanvasUserChange < ApplicationRecord
   validates :admin_making_changes_lms_id, :user_being_changed_lms_id, presence: true
+
+  def self.create_by_diffing_attrs(
+    admin_making_changes_lms_id:,
+    user_being_changed_lms_id:,
+    original_attrs:,
+    new_attrs:,
+    failed_attrs: []
+  )
+    record_attrs = {
+      admin_making_changes_lms_id: admin_making_changes_lms_id,
+      user_being_changed_lms_id: user_being_changed_lms_id,
+    }
+
+    [:name, :login_id, :sis_user_id, :email].each do |attr|
+      next if original_attrs[attr] == new_attrs[attr] || new_attrs[attr].nil?
+
+      record_attrs[attr] = {
+        previous_value: original_attrs[attr],
+        new_value: new_attrs[attr],
+        success: failed_attrs.exclude?(attr),
+      }
+    end
+
+    if new_attrs[:password].present?
+      record_attrs[:password] = {
+        previous_value: "[FILTERED]",
+        new_value: "[FILTERED]",
+        success: failed_attrs.exclude?(:password),
+      }
+    end
+
+    create(record_attrs)
+  end
 end

--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -1,0 +1,3 @@
+class CanvasUserChange < ApplicationRecord
+  validates :admin_making_changes_lms_id, :user_being_changed_lms_id, presence: true
+end

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -26,7 +26,7 @@ export const updateUser = (userId, userAttributes) => {
       login_id: userAttributes.loginId,
       sis_user_id: userAttributes.sisUserId,
       email: userAttributes.email,
-    }
+    },
   };
 
   if (userAttributes.password !== '') {

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -19,9 +19,8 @@ export const searchForAccountUsers = (searchTerm, page) => ({
   },
 });
 
-export const updateUser = (userId, originalUserLoginId, userAttributes) => {
+export const updateUser = (userId, userAttributes) => {
   const body = {
-    original_user_login_id: originalUserLoginId,
     user: {
       name: userAttributes.name,
       login_id: userAttributes.loginId,

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -39,7 +39,6 @@ describe('application actions', () => {
 
   describe('updateUser', () => {
     const userId = 45;
-    const originalUserLoginId = 'adamsforindepence@greatbritain.com';
     const userAttributes = {
       name: 'John Adams',
       loginId: 'adamsforindependence@revolution.com',
@@ -54,7 +53,6 @@ describe('application actions', () => {
         method: 'put',
         url: `api/canvas_account_users/${userId}`,
         body: {
-          original_user_login_id: originalUserLoginId,
           user: {
             name: userAttributes.name,
             login_id: userAttributes.loginId,
@@ -65,7 +63,7 @@ describe('application actions', () => {
         }
       };
 
-      expect(updateUser(userId, originalUserLoginId, userAttributes))
+      expect(updateUser(userId, userAttributes))
         .toEqual(expectedAction);
     });
 
@@ -78,7 +76,6 @@ describe('application actions', () => {
           method: 'put',
           url: `api/canvas_account_users/${userId}`,
           body: {
-            original_user_login_id: originalUserLoginId,
             user: {
               name: userAttributes.name,
               login_id: userAttributes.loginId,
@@ -88,7 +85,7 @@ describe('application actions', () => {
           }
         };
 
-        expect(updateUser(userId, originalUserLoginId, userAttributes))
+        expect(updateUser(userId, userAttributes))
           .toEqual(expectedAction);
       });
     });

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -59,8 +59,8 @@ describe('application actions', () => {
             sis_user_id: userAttributes.sisUserId,
             email: userAttributes.email,
             password: userAttributes.password,
-          }
-        }
+          },
+        },
       };
 
       expect(updateUser(userId, userAttributes))
@@ -81,8 +81,8 @@ describe('application actions', () => {
               login_id: userAttributes.loginId,
               sis_user_id: userAttributes.sisUserId,
               email: userAttributes.email,
-            }
-          }
+            },
+          },
         };
 
         expect(updateUser(userId, userAttributes))

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -54,7 +54,7 @@ export class EditUserModal extends React.Component {
     } = this.props;
     const { userForm } = this.state;
 
-    update(user.id, user.login_id, userForm);
+    update(user.id, userForm);
 
     closeModal();
   }

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -85,7 +85,6 @@ describe('EditUserModal', () => {
 
       expect(props.updateUser).toHaveBeenCalledWith(
         props.user.id,
-        props.user.login_id,
         {
           name: newName,
           loginId: newLoginId,

--- a/db/migrate/20200409204253_create_canvas_user_changes.rb
+++ b/db/migrate/20200409204253_create_canvas_user_changes.rb
@@ -1,0 +1,16 @@
+class CreateCanvasUserChanges < ActiveRecord::Migration[5.2]
+  def change
+    create_table :canvas_user_changes do |t|
+      t.bigint :admin_making_changes_lms_id, null: false
+      t.bigint :user_being_changed_lms_id, null: false
+
+      t.json :name
+      t.json :login_id
+      t.json :password
+      t.json :sis_user_id
+      t.json :email
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200414192353_add_failed_attributes_to_canvas_user_changes.rb
+++ b/db/migrate/20200414192353_add_failed_attributes_to_canvas_user_changes.rb
@@ -1,0 +1,5 @@
+class AddFailedAttributesToCanvasUserChanges < ActiveRecord::Migration[5.2]
+  def change
+    add_column :canvas_user_changes, :failed_attributes, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_194920) do
+ActiveRecord::Schema.define(version: 2020_04_09_204253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,6 +153,18 @@ ActiveRecord::Schema.define(version: 2020_02_26_194920) do
     t.string "key"
     t.boolean "shared_tenant", default: false
     t.index ["key"], name: "index_bundles_on_key"
+  end
+
+  create_table "canvas_user_changes", force: :cascade do |t|
+    t.bigint "admin_making_changes_lms_id", null: false
+    t.bigint "user_being_changed_lms_id", null: false
+    t.json "name"
+    t.json "login_id"
+    t.json "password"
+    t.json "sis_user_id"
+    t.json "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "courses", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_09_204253) do
+ActiveRecord::Schema.define(version: 2020_04_14_192353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -165,6 +165,7 @@ ActiveRecord::Schema.define(version: 2020_04_09_204253) do
     t.json "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "failed_attributes", array: true
   end
 
   create_table "courses", force: :cascade do |t|

--- a/spec/controllers/api/canvas_account_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_account_users_controller_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
     let(:params) do
       {
         id: "412",
-        original_user_login_id: "adamsforindepence@greatbritain.com",
         user: {
           name: "John Adams",
           login_id: "adamsforindependence@revolution.com",
@@ -94,9 +93,22 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
         },
       }
     end
+    let(:original_user) do
+      {
+        id: "412",
+        name: "John Adams",
+        login_id: "adamsforindependence@greatbritain.com",
+        sis_user_id: "old_john_123",
+        email: "adamsforindependence@greatbritain.com",
+      }
+    end
     let(:numeric_login_id) { 4989 }
 
     before do
+      allow_any_instance_of(LMS::Canvas).to receive(:api_get_request).
+        with(a_string_matching(/users\?.*search_term=#{params[:id]}/i)).
+        and_return([original_user])
+
       allow_any_instance_of(LMS::Canvas).to receive(:api_put_request).
         with("users/#{params[:id]}", anything).
         and_return(
@@ -108,9 +120,9 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
         and_return(
           [{
             "id" => numeric_login_id,
-            "user_id" => params[:id],
-            "unique_id" => params[:original_user_login_id],
-            "sis_user_id" => "#{params[:user][:sis_user_id]}(old)",
+            "user_id" => original_user[:id],
+            "unique_id" => original_user[:login_id],
+            "sis_user_id" => original_user[:sis_user_id],
           }],
         )
 

--- a/spec/controllers/api/canvas_account_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_account_users_controller_spec.rb
@@ -95,11 +95,11 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
     end
     let(:original_user) do
       {
-        id: "412",
-        name: "John Adams",
-        login_id: "adamsforindependence@greatbritain.com",
-        sis_user_id: "old_john_123",
-        email: "adamsforindependence@greatbritain.com",
+        "id" => "412",
+        "name" => "John Adams",
+        "login_id" => "adamsforindependence@greatbritain.com",
+        "sis_user_id" => "old_john_123",
+        "email" => "adamsforindependence@greatbritain.com",
       }
     end
     let(:numeric_login_id) { 4989 }
@@ -120,9 +120,9 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
         and_return(
           [{
             "id" => numeric_login_id,
-            "user_id" => original_user[:id],
-            "unique_id" => original_user[:login_id],
-            "sis_user_id" => original_user[:sis_user_id],
+            "user_id" => original_user["id"],
+            "unique_id" => original_user["login_id"],
+            "sis_user_id" => original_user["sis_user_id"],
           }],
         )
 

--- a/spec/factories/canvas_user_changes.rb
+++ b/spec/factories/canvas_user_changes.rb
@@ -1,0 +1,34 @@
+FactoryBot.define do
+  factory :canvas_user_change do
+    admin_making_changes_lms_id { FactoryBot.generate(:lms_user_id) }
+    user_being_changed_lms_id { FactoryBot.generate(:lms_user_id) }
+
+    previous_name = FactoryBot.generate(:student_name)
+    previous_email = FactoryBot.generate(:email)
+    previous_sis_user_id = FactoryBot.generate(:sis_user_id)
+
+    name do
+      { previous_value: previous_name, new_value: "#{previous_name}_updated", success: true }
+    end
+
+    login_id do
+      { previous_value: previous_email, new_value: "updated_#{previous_email}", success: true }
+    end
+
+    password do
+      { previous_value: "[FILTERED]", new_value: "[FILTERED]", success: true }
+    end
+
+    sis_user_id do
+      {
+        previous_value: previous_sis_user_id,
+        new_value: "#{previous_sis_user_id}_updated",
+        success: true,
+      }
+    end
+
+    email do
+      { previous_value: previous_email, new_value: "updated_#{previous_email}", success: true }
+    end
+  end
+end

--- a/spec/models/canvas_user_change_spec.rb
+++ b/spec/models/canvas_user_change_spec.rb
@@ -159,14 +159,14 @@ RSpec.describe CanvasUserChange, type: :model do
     end
   end
 
-  describe ".has_failed_attributes?" do
+  describe ".failed_attributes?" do
     context "when the failed_attributes field is nil" do
       let(:canvas_user_change) do
         FactoryBot.create(:canvas_user_change, failed_attributes: nil)
       end
 
       it "returns false" do
-        expect(canvas_user_change.has_failed_attributes?).to be false
+        expect(canvas_user_change.failed_attributes?).to be false
       end
     end
 
@@ -176,7 +176,7 @@ RSpec.describe CanvasUserChange, type: :model do
       end
 
       it "returns false" do
-        expect(canvas_user_change.has_failed_attributes?).to be false
+        expect(canvas_user_change.failed_attributes?).to be false
       end
     end
 
@@ -186,7 +186,7 @@ RSpec.describe CanvasUserChange, type: :model do
       end
 
       it "returns true" do
-        expect(canvas_user_change.has_failed_attributes?).to be true
+        expect(canvas_user_change.failed_attributes?).to be true
       end
     end
   end

--- a/spec/models/canvas_user_change_spec.rb
+++ b/spec/models/canvas_user_change_spec.rb
@@ -138,6 +138,10 @@ RSpec.describe CanvasUserChange, type: :model do
       it "marks the attribute with success: false" do
         expect(@canvas_user_change.email["success"]).to be false
       end
+
+      it "populates the failed_attributes field" do
+        expect(@canvas_user_change.failed_attributes).to eq(["email"])
+      end
     end
 
     context "when the record is invalid" do

--- a/spec/models/canvas_user_change_spec.rb
+++ b/spec/models/canvas_user_change_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CanvasUserChange, type: :model do
-  describe ".create_by_diffing_attrs" do
+  describe ".create_by_diffing_attrs!" do
     let(:admin_id) { 123 }
     let(:user_id) { 456 }
     let(:original_attrs) do
@@ -23,7 +23,7 @@ RSpec.describe CanvasUserChange, type: :model do
     end
 
     before do
-      @canvas_user_change = described_class.create_by_diffing_attrs(
+      @canvas_user_change = described_class.create_by_diffing_attrs!(
         admin_making_changes_lms_id: admin_id,
         user_being_changed_lms_id: user_id,
         original_attrs: original_attrs,
@@ -33,7 +33,7 @@ RSpec.describe CanvasUserChange, type: :model do
 
     it "creates a record in the database" do
       expect do
-        described_class.create_by_diffing_attrs(
+        described_class.create_by_diffing_attrs!(
           admin_making_changes_lms_id: admin_id,
           user_being_changed_lms_id: user_id,
           original_attrs: original_attrs,
@@ -94,7 +94,7 @@ RSpec.describe CanvasUserChange, type: :model do
       before do
         new_attrs.delete(:email)
 
-        @canvas_user_change = described_class.create_by_diffing_attrs(
+        @canvas_user_change = described_class.create_by_diffing_attrs!(
           admin_making_changes_lms_id: admin_id,
           user_being_changed_lms_id: user_id,
           original_attrs: original_attrs,
@@ -111,7 +111,7 @@ RSpec.describe CanvasUserChange, type: :model do
       before do
         new_attrs[:email] = original_attrs[:email]
 
-        @canvas_user_change = described_class.create_by_diffing_attrs(
+        @canvas_user_change = described_class.create_by_diffing_attrs!(
           admin_making_changes_lms_id: admin_id,
           user_being_changed_lms_id: user_id,
           original_attrs: original_attrs,
@@ -126,7 +126,7 @@ RSpec.describe CanvasUserChange, type: :model do
 
     context "when the attribute is in the failed_attrs list" do
       before do
-        @canvas_user_change = described_class.create_by_diffing_attrs(
+        @canvas_user_change = described_class.create_by_diffing_attrs!(
           admin_making_changes_lms_id: admin_id,
           user_being_changed_lms_id: user_id,
           original_attrs: original_attrs,
@@ -137,6 +137,20 @@ RSpec.describe CanvasUserChange, type: :model do
 
       it "marks the attribute with success: false" do
         expect(@canvas_user_change.email["success"]).to be false
+      end
+    end
+
+    context "when the record is invalid" do
+      it "raises an exception" do
+        expect do
+          described_class.create_by_diffing_attrs!(
+            admin_making_changes_lms_id: nil,
+            user_being_changed_lms_id: nil,
+            original_attrs: original_attrs,
+            new_attrs: new_attrs,
+            failed_attrs: [:email],
+          )
+        end.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end

--- a/spec/models/canvas_user_change_spec.rb
+++ b/spec/models/canvas_user_change_spec.rb
@@ -158,4 +158,36 @@ RSpec.describe CanvasUserChange, type: :model do
       end
     end
   end
+
+  describe ".has_failed_attributes?" do
+    context "when the failed_attributes field is nil" do
+      let(:canvas_user_change) do
+        FactoryBot.create(:canvas_user_change, failed_attributes: nil)
+      end
+
+      it "returns false" do
+        expect(canvas_user_change.has_failed_attributes?).to be false
+      end
+    end
+
+    context "when the failed_attributes field is an empty array" do
+      let(:canvas_user_change) do
+        FactoryBot.create(:canvas_user_change, failed_attributes: [])
+      end
+
+      it "returns false" do
+        expect(canvas_user_change.has_failed_attributes?).to be false
+      end
+    end
+
+    context "when the failed_attributes field is not empty" do
+      let(:canvas_user_change) do
+        FactoryBot.create(:canvas_user_change, failed_attributes: [:email])
+      end
+
+      it "returns true" do
+        expect(canvas_user_change.has_failed_attributes?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/canvas_user_change_spec.rb
+++ b/spec/models/canvas_user_change_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+RSpec.describe CanvasUserChange, type: :model do
+  describe ".create_by_diffing_attrs" do
+    let(:admin_id) { 123 }
+    let(:user_id) { 456 }
+    let(:original_attrs) do
+      {
+        name: "Old John Adams",
+        login_id: "adamsforindependence@greatbritain.com",
+        sis_user_id: "old_john_123",
+        email: "adamsforindependence@greatbritain.com",
+      }
+    end
+    let(:new_attrs) do
+      {
+        name: "John Adams",
+        login_id: "adamsforindependence@revolution.com",
+        sis_user_id: "john_123",
+        email: "adamsforindependence@revolution.com",
+        password: "new_password",
+      }
+    end
+
+    before do
+      @canvas_user_change = described_class.create_by_diffing_attrs(
+        admin_making_changes_lms_id: admin_id,
+        user_being_changed_lms_id: user_id,
+        original_attrs: original_attrs,
+        new_attrs: new_attrs,
+      )
+    end
+
+    it "creates a record in the database" do
+      expect do
+        described_class.create_by_diffing_attrs(
+          admin_making_changes_lms_id: admin_id,
+          user_being_changed_lms_id: user_id,
+          original_attrs: original_attrs,
+          new_attrs: new_attrs,
+        )
+      end.to change(CanvasUserChange, :count).by(1)
+    end
+
+    it "populates the admin_making_changes_lms_id field" do
+      expect(@canvas_user_change.admin_making_changes_lms_id).to eq(admin_id)
+    end
+
+    it "populates the user_being_changed_lms_id field" do
+      expect(@canvas_user_change.user_being_changed_lms_id).to eq(user_id)
+    end
+
+    it "populates the name field" do
+      expect(@canvas_user_change.name).to eq(
+        "previous_value" => original_attrs[:name],
+        "new_value" => new_attrs[:name],
+        "success" => true,
+      )
+    end
+
+    it "populates the login_id field" do
+      expect(@canvas_user_change.login_id).to eq(
+        "previous_value" => original_attrs[:login_id],
+        "new_value" => new_attrs[:login_id],
+        "success" => true,
+      )
+    end
+
+    it "populates the password field" do
+      expect(@canvas_user_change.password).to eq(
+        "previous_value" => "[FILTERED]",
+        "new_value" => "[FILTERED]",
+        "success" => true,
+      )
+    end
+
+    it "populates the sis_user_id field" do
+      expect(@canvas_user_change.sis_user_id).to eq(
+        "previous_value" => original_attrs[:sis_user_id],
+        "new_value" => new_attrs[:sis_user_id],
+        "success" => true,
+      )
+    end
+
+    it "populates the email field" do
+      expect(@canvas_user_change.email).to eq(
+        "previous_value" => original_attrs[:email],
+        "new_value" => new_attrs[:email],
+        "success" => true,
+      )
+    end
+
+    context "when an attribute is nil" do
+      before do
+        new_attrs.delete(:email)
+
+        @canvas_user_change = described_class.create_by_diffing_attrs(
+          admin_making_changes_lms_id: admin_id,
+          user_being_changed_lms_id: user_id,
+          original_attrs: original_attrs,
+          new_attrs: new_attrs,
+        )
+      end
+
+      it "doesn't populate that field" do
+        expect(@canvas_user_change.email).to be_nil
+      end
+    end
+
+    context "when the new attribute is equal to the original attribute" do
+      before do
+        new_attrs[:email] = original_attrs[:email]
+
+        @canvas_user_change = described_class.create_by_diffing_attrs(
+          admin_making_changes_lms_id: admin_id,
+          user_being_changed_lms_id: user_id,
+          original_attrs: original_attrs,
+          new_attrs: new_attrs,
+        )
+      end
+
+      it "doesn't populate that field" do
+        expect(@canvas_user_change.email).to be_nil
+      end
+    end
+
+    context "when the attribute is in the failed_attrs list" do
+      before do
+        @canvas_user_change = described_class.create_by_diffing_attrs(
+          admin_making_changes_lms_id: admin_id,
+          user_being_changed_lms_id: user_id,
+          original_attrs: original_attrs,
+          new_attrs: new_attrs,
+          failed_attrs: [:email],
+        )
+      end
+
+      it "marks the attribute with success: false" do
+        expect(@canvas_user_change.email["success"]).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171524499](https://www.pivotaltracker.com/story/show/171524499)

This branch adds logging for changes to Canvas user data. When someone attempts to change user data, a record in the database is created specifying the data being changed and who is changing it. This record is created whether or not the request succeeds and the changes are actually applied.

## Implementation
The method that creates the logging record for the user change raises an exception if the record is invalid. I think this makes sense because we're using this method to log changes to sensitive user data. If the record is invalid and the logging record isn't created, we want to know about it.

## Demo
Here are a couple of examples of how the database records look:

**Success**
![success](https://user-images.githubusercontent.com/6520489/79251357-468d6d80-7e3d-11ea-8912-89f30b8fbc1e.png)

**Partial Success**
![partial_success](https://user-images.githubusercontent.com/6520489/79251370-48efc780-7e3d-11ea-9422-b0ef6e0238b5.png)