### PR TITLE
Prevent Editing of Admin Users

### DIFF
--- a/app/controllers/api/canvas_account_users_controller.rb
+++ b/app/controllers/api/canvas_account_users_controller.rb
@@ -4,7 +4,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
   before_action :validate_token
   before_action :validate_current_user_lti_admin
   before_action :fetch_original_user, only: [:update]
-  before_action :validate_user_is_in_account, only: [:update]
+  before_action :validate_user_being_changed_is_in_account, only: [:update]
 
   # This action only lists users who are members of the Canvas account given in the LTI launch.
   # Users from sub-accounts of that account are also included.
@@ -72,7 +72,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     @original_user = HashWithIndifferentAccess.new(original_user)
   end
 
-  def validate_user_is_in_account
+  def validate_user_being_changed_is_in_account
     user_is_in_account = @original_user.present?
 
     unless user_is_in_account


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171524424](https://www.pivotaltracker.com/story/show/171524424)

We concluded that the most secure way to handle updating admin users was to just not do it. This branch adds a check to determine if the user being updated is an admin an any account in Canvas. If they are, we return a 401 Unauthorized instead of updating them.

## Implementation
To determine if the user being updated is an admin somewhere, we call the [List accounts](https://canvas.instructure.com/doc/api/accounts.html#method.accounts.index) endpoint. The docs for that endpoint state, "Typically, students and even teachers will get an empty list in response, only account admins can view the accounts that they are in." If we get a non-empty response from the endpoint, we assume the user being edited is an admin in some account and refuse to update them.

Admittedly, that statement from the docs seems a little ambiguous to me. Is it saying that it's always true that only account admins can view the accounts that they are in, or is it saying that that is the typical case? I think it's the former, but I'm not positive. My personal testing seemed to suggest it was the former. If that's wrong, we might accidentally prevent editing of some non-admin users; our code won't allow the editing of admins in either case though.

## Demo
![prevent_editing_admins](https://user-images.githubusercontent.com/6520489/79391668-32c23400-7f2f-11ea-8cb0-eb3a7ab22946.gif)