### PR TITLE
Remove Roles Table Cell From User Search Results

### DIFF
--- a/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/user_search_result.spec.jsx.snap
@@ -20,10 +20,6 @@ exports[`UserSearchResult renders the user as a search result 1`] = `
       george_123
     </td>
     <td>
-      admin
-      teacher
-    </td>
-    <td>
       countryfather@revolution.com
     </td>
   </tr>
@@ -35,10 +31,6 @@ exports[`UserSearchResult renders the user as a search result 1`] = `
         "email": "countryfather@revolution.com",
         "login_id": "countryfather@revolution.com",
         "name": "George Washington",
-        "roles": Array [
-          "admin",
-          "teacher",
-        ],
         "sis_user_id": "george_123",
       }
     }

--- a/client/apps/user_tool/components/main/user_search_result.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.jsx
@@ -31,7 +31,6 @@ export default class UserSearchResult extends React.Component {
           </th>
           <td>{user.login_id}</td>
           <td>{user.sis_user_id}</td>
-          <td>{user.roles}</td>
           <td>{user.email}</td>
         </tr>
 

--- a/client/apps/user_tool/components/main/user_search_result.spec.jsx
+++ b/client/apps/user_tool/components/main/user_search_result.spec.jsx
@@ -8,7 +8,6 @@ describe('UserSearchResult', () => {
     name: 'George Washington',
     login_id: 'countryfather@revolution.com',
     sis_user_id: 'george_123',
-    roles: ['admin', 'teacher'],
     email: 'countryfather@revolution.com',
   };
 


### PR DESCRIPTION
This should have been removed in #407 when we removed roles from the search page component. I made a mistake though and forgot to remove it from here.