### PR TITLE
Remove the Ability to Change a User's Password

### DIFF
--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -1,6 +1,7 @@
 class CanvasUserChange < ApplicationRecord
   validates :admin_making_changes_lms_id, :user_being_changed_lms_id, presence: true
 
+  # Accepted attrs are :name, :login_id, :sis_user_id and :email.
   def self.create_by_diffing_attrs!(
     admin_making_changes_lms_id:,
     user_being_changed_lms_id:,
@@ -21,14 +22,6 @@ class CanvasUserChange < ApplicationRecord
         previous_value: original_attrs[attr],
         new_value: new_attrs[attr],
         success: failed_attrs.exclude?(attr),
-      }
-    end
-
-    if new_attrs[:password].present?
-      record_attrs[:password] = {
-        previous_value: "[FILTERED]",
-        new_value: "[FILTERED]",
-        success: failed_attrs.exclude?(:password),
       }
     end
 

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -19,24 +19,16 @@ export const searchForAccountUsers = (searchTerm, page) => ({
   },
 });
 
-export const updateUser = (userId, userAttributes) => {
-  const body = {
+export const updateUser = (userId, userAttributes) => ({
+  type: Constants.UPDATE_USER,
+  method: Network.PUT,
+  url: `api/canvas_account_users/${userId}`,
+  body: {
     user: {
       name: userAttributes.name,
       login_id: userAttributes.loginId,
       sis_user_id: userAttributes.sisUserId,
       email: userAttributes.email,
     },
-  };
-
-  if (userAttributes.password !== '') {
-    body.user.password = userAttributes.password;
-  }
-
-  return {
-    type: Constants.UPDATE_USER,
-    method: Network.PUT,
-    url: `api/canvas_account_users/${userId}`,
-    body,
-  };
-};
+  },
+});

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -42,7 +42,6 @@ describe('application actions', () => {
     const userAttributes = {
       name: 'John Adams',
       loginId: 'adamsforindependence@revolution.com',
-      password: 'new_password',
       sisUserId: 'john_123',
       email: 'adamsforindependence@revolution.com'
     };
@@ -58,36 +57,12 @@ describe('application actions', () => {
             login_id: userAttributes.loginId,
             sis_user_id: userAttributes.sisUserId,
             email: userAttributes.email,
-            password: userAttributes.password,
           },
         },
       };
 
       expect(updateUser(userId, userAttributes))
         .toEqual(expectedAction);
-    });
-
-    describe('when no password is given', () => {
-      it('does not send a password property', () => {
-        delete userAttributes.password;
-
-        const expectedAction = {
-          type: 'UPDATE_USER',
-          method: 'put',
-          url: `api/canvas_account_users/${userId}`,
-          body: {
-            user: {
-              name: userAttributes.name,
-              login_id: userAttributes.loginId,
-              sis_user_id: userAttributes.sisUserId,
-              email: userAttributes.email,
-            },
-          },
-        };
-
-        expect(updateUser(userId, userAttributes))
-          .toEqual(expectedAction);
-      });
     });
   });
 });

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -45,7 +45,7 @@ exports[`EditUserModal renders the edit user modal 1`] = `
         className="row"
       >
         <div
-          className="column u-half"
+          className="column"
         >
           <div
             className="input"
@@ -95,10 +95,6 @@ exports[`EditUserModal renders the edit user modal 1`] = `
               value="countryfather@revolution.com"
             />
           </div>
-        </div>
-        <div
-          className="column u-half"
-        >
           <div
             className="input"
           >
@@ -149,7 +145,7 @@ exports[`EditUserModal when the user clicks the Update button renders the change
       className="row"
     >
       <div
-        className="column u-half"
+        className="column"
       >
         <div
           className="input"
@@ -211,10 +207,6 @@ exports[`EditUserModal when the user clicks the Update button renders the change
             countryfather@revolution.com
           </span>
         </div>
-      </div>
-      <div
-        className="column u-half"
-      >
         <div
           className="input"
         >

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -115,23 +115,6 @@ exports[`EditUserModal renders the edit user modal 1`] = `
               value="countryfather@revolution.com"
             />
           </div>
-          <div
-            className="input"
-          >
-            <label
-              htmlFor="user_password"
-            >
-              New Password
-            </label>
-            <input
-              id="user_password"
-              name="password"
-              onChange={[Function]}
-              placeholder="****************"
-              type="password"
-              value=""
-            />
-          </div>
         </div>
       </div>
     </div>
@@ -250,26 +233,6 @@ exports[`EditUserModal when the user clicks the Update button renders the change
           <span>
             Was: 
             countryfather@revolution.com
-          </span>
-        </div>
-        <div
-          className="input"
-        >
-          <label
-            htmlFor="user_password"
-          >
-            New Password
-          </label>
-          <input
-            id="user_password"
-            name="password"
-            onChange={[Function]}
-            placeholder="****************"
-            type="password"
-            value="Updated Password"
-          />
-          <span>
-            Changed
           </span>
         </div>
       </div>

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -45,7 +45,7 @@ exports[`EditUserModal renders the edit user modal 1`] = `
         className="row"
       >
         <div
-          className="column"
+          className="column u-half"
         >
           <div
             className="input"
@@ -95,6 +95,10 @@ exports[`EditUserModal renders the edit user modal 1`] = `
               value="countryfather@revolution.com"
             />
           </div>
+        </div>
+        <div
+          className="column u-half"
+        >
           <div
             className="input"
           >
@@ -145,7 +149,7 @@ exports[`EditUserModal when the user clicks the Update button renders the change
       className="row"
     >
       <div
-        className="column"
+        className="column u-half"
       >
         <div
           className="input"
@@ -207,6 +211,10 @@ exports[`EditUserModal when the user clicks the Update button renders the change
             countryfather@revolution.com
           </span>
         </div>
+      </div>
+      <div
+        className="column u-half"
+      >
         <div
           className="input"
         >

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -79,6 +79,10 @@ exports[`EditUserModal renders the edit user modal 1`] = `
               value="george_123"
             />
           </div>
+        </div>
+        <div
+          className="column u-half"
+        >
           <div
             className="input"
           >
@@ -95,10 +99,6 @@ exports[`EditUserModal renders the edit user modal 1`] = `
               value="countryfather@revolution.com"
             />
           </div>
-        </div>
-        <div
-          className="column u-half"
-        >
           <div
             className="input"
           >
@@ -191,6 +191,10 @@ exports[`EditUserModal when the user clicks the Update button renders the change
             george_123
           </span>
         </div>
+      </div>
+      <div
+        className="column u-half"
+      >
         <div
           className="input"
         >
@@ -211,10 +215,6 @@ exports[`EditUserModal when the user clicks the Update button renders the change
             countryfather@revolution.com
           </span>
         </div>
-      </div>
-      <div
-        className="column u-half"
-      >
         <div
           className="input"
         >

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -23,7 +23,6 @@ export class EditUserModal extends React.Component {
       userForm: {
         name: user.name,
         loginId: user.login_id,
-        password: '',
         sisUserId: user.sis_user_id,
         email: user.email
       },
@@ -81,14 +80,6 @@ export class EditUserModal extends React.Component {
 
     if (!confirmingUpdates || userForm[_.camelCase(attribute)] === user[attribute]) {
       return false;
-    }
-
-    if (attribute === 'password') {
-      if (_.isEmpty(userForm.password)) {
-        return false;
-      }
-
-      return <span>Changed</span>;
     }
 
     return <span>Was: {user[attribute]}</span>;
@@ -195,18 +186,6 @@ export class EditUserModal extends React.Component {
                     onChange={this.handleInputChange}
                   />
                   { this.renderAttributeChange('login_id') }
-                </div>
-                <div className="input">
-                  <label htmlFor="user_password">New Password</label>
-                  <input
-                    id="user_password"
-                    name="password"
-                    type="password"
-                    value={userForm.password}
-                    placeholder="****************"
-                    onChange={this.handleInputChange}
-                  />
-                  { this.renderAttributeChange('password') }
                 </div>
               </div>
             </div>

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -140,7 +140,7 @@ export class EditUserModal extends React.Component {
         <form>
           <div className="modal__main">
             <div className="row">
-              <div className="column">
+              <div className="column u-half">
                 <div className="input">
                   <label htmlFor="user_name">Name</label>
                   <input
@@ -174,6 +174,8 @@ export class EditUserModal extends React.Component {
                   />
                   { this.renderAttributeChange('email') }
                 </div>
+              </div>
+              <div className="column u-half">
                 <div className="input">
                   <label htmlFor="user_login_id">Login ID</label>
                   <input

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -140,7 +140,7 @@ export class EditUserModal extends React.Component {
         <form>
           <div className="modal__main">
             <div className="row">
-              <div className="column u-half">
+              <div className="column">
                 <div className="input">
                   <label htmlFor="user_name">Name</label>
                   <input
@@ -174,8 +174,6 @@ export class EditUserModal extends React.Component {
                   />
                   { this.renderAttributeChange('email') }
                 </div>
-              </div>
-              <div className="column u-half">
                 <div className="input">
                   <label htmlFor="user_login_id">Login ID</label>
                   <input

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -163,6 +163,8 @@ export class EditUserModal extends React.Component {
                   />
                   { this.renderAttributeChange('sis_user_id') }
                 </div>
+              </div>
+              <div className="column u-half">
                 <div className="input">
                   <label htmlFor="user_email">Email</label>
                   <input
@@ -174,8 +176,6 @@ export class EditUserModal extends React.Component {
                   />
                   { this.renderAttributeChange('email') }
                 </div>
-              </div>
-              <div className="column u-half">
                 <div className="input">
                   <label htmlFor="user_login_id">Login ID</label>
                   <input

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -134,24 +134,20 @@ describe('EditUserModal', () => {
       );
       const nameInput = modal.find('#user_name');
       const loginIdInput = modal.find('#user_login_id');
-      const passwordInput = modal.find('#user_password');
       const sisUserIdInput = modal.find('#user_sis_user_id');
       const emailInput = modal.find('#user_email');
       const newName = 'Updated Name';
       const newLoginId = 'Update Login Id';
-      const newPassword = 'Updated Password';
       const newSisUserId = 'Updated SIS ID';
       const newEmail = 'Updated Email';
 
       expect(nameInput.prop('value')).toEqual(props.user.name);
       expect(loginIdInput.prop('value')).toEqual(props.user.login_id);
-      expect(passwordInput.prop('value')).toEqual('');
       expect(sisUserIdInput.prop('value')).toEqual(props.user.sis_user_id);
       expect(emailInput.prop('value')).toEqual(props.user.email);
 
       nameInput.simulate('change', { target: { name: 'name', value: newName } });
       loginIdInput.simulate('change', { target: { name: 'loginId', value: newLoginId } });
-      passwordInput.simulate('change', { target: { name: 'password', value: newPassword } });
       sisUserIdInput.simulate('change', { target: { name: 'sisUserId', value: newSisUserId } });
       emailInput.simulate('change', { target: { name: 'email', value: newEmail } });
 
@@ -164,7 +160,6 @@ describe('EditUserModal', () => {
         {
           name: newName,
           loginId: newLoginId,
-          password: newPassword,
           sisUserId: newSisUserId,
           email: newEmail,
         },
@@ -246,13 +241,11 @@ describe('EditUserModal', () => {
       const submitButton = modal.find('button[type="submit"]');
       const nameInput = modal.find('#user_name');
       const loginIdInput = modal.find('#user_login_id');
-      const passwordInput = modal.find('#user_password');
       const sisUserIdInput = modal.find('#user_sis_user_id');
       const emailInput = modal.find('#user_email');
 
       nameInput.simulate('change', { target: { name: 'name', value: 'Updated Name' } });
       loginIdInput.simulate('change', { target: { name: 'loginId', value: 'Updated Login Id' } });
-      passwordInput.simulate('change', { target: { name: 'password', value: 'Updated Password' } });
       sisUserIdInput.simulate('change', { target: { name: 'sisUserId', value: 'Updated SIS ID' } });
       emailInput.simulate('change', { target: { name: 'email', value: 'Updated Email' } });
 

--- a/client/apps/user_tool/styles/partials/_index.scss
+++ b/client/apps/user_tool/styles/partials/_index.scss
@@ -14,9 +14,3 @@
   width: 100%;
   padding-left: $row-spacing;
 }
-
-@media (min-width: 670px){
-  .u-half{
-    width: 50% !important;
-  }
-}

--- a/client/apps/user_tool/styles/partials/_index.scss
+++ b/client/apps/user_tool/styles/partials/_index.scss
@@ -14,3 +14,9 @@
   width: 100%;
   padding-left: $row-spacing;
 }
+
+@media (min-width: 670px){
+  .u-half{
+    width: 50% !important;
+  }
+}

--- a/db/migrate/20200417204937_remove_password_from_canvas_user_changes.rb
+++ b/db/migrate/20200417204937_remove_password_from_canvas_user_changes.rb
@@ -1,0 +1,5 @@
+class RemovePasswordFromCanvasUserChanges < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :canvas_user_changes, :password, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_192353) do
+ActiveRecord::Schema.define(version: 2020_04_17_204937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -160,7 +160,6 @@ ActiveRecord::Schema.define(version: 2020_04_14_192353) do
     t.bigint "user_being_changed_lms_id", null: false
     t.json "name"
     t.json "login_id"
-    t.json "password"
     t.json "sis_user_id"
     t.json "email"
     t.datetime "created_at", null: false

--- a/spec/controllers/api/canvas_account_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_account_users_controller_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
           login_id: "adamsforindependence@revolution.com",
           sis_user_id: "john_123",
           email: "adamsforindependence@revolution.com",
-          password: "new_password",
         },
       }
     end
@@ -275,7 +274,7 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
             user_being_changed_lms_id: params[:id],
             original_attrs: original_user,
             new_attrs: params[:user],
-            failed_attrs: [:name, :email, :login_id, :password, :sis_user_id],
+            failed_attrs: [:name, :email, :login_id, :sis_user_id],
           )
       end
     end
@@ -318,7 +317,7 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
             user_being_changed_lms_id: params[:id],
             original_attrs: original_user,
             new_attrs: params[:user],
-            failed_attrs: [:login_id, :password, :sis_user_id],
+            failed_attrs: [:login_id, :sis_user_id],
           )
       end
     end
@@ -362,7 +361,7 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
             user_being_changed_lms_id: params[:id],
             original_attrs: original_user,
             new_attrs: params[:user],
-            failed_attrs: [:login_id, :password, :sis_user_id],
+            failed_attrs: [:login_id, :sis_user_id],
           )
       end
     end

--- a/spec/factories/canvas_user_changes.rb
+++ b/spec/factories/canvas_user_changes.rb
@@ -15,10 +15,6 @@ FactoryBot.define do
       { previous_value: previous_email, new_value: "updated_#{previous_email}", success: true }
     end
 
-    password do
-      { previous_value: "[FILTERED]", new_value: "[FILTERED]", success: true }
-    end
-
     sis_user_id do
       {
         previous_value: previous_sis_user_id,

--- a/spec/models/canvas_user_change_spec.rb
+++ b/spec/models/canvas_user_change_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe CanvasUserChange, type: :model do
         login_id: "adamsforindependence@revolution.com",
         sis_user_id: "john_123",
         email: "adamsforindependence@revolution.com",
-        password: "new_password",
       }
     end
 
@@ -62,14 +61,6 @@ RSpec.describe CanvasUserChange, type: :model do
       expect(@canvas_user_change.login_id).to eq(
         "previous_value" => original_attrs[:login_id],
         "new_value" => new_attrs[:login_id],
-        "success" => true,
-      )
-    end
-
-    it "populates the password field" do
-      expect(@canvas_user_change.password).to eq(
-        "previous_value" => "[FILTERED]",
-        "new_value" => "[FILTERED]",
         "success" => true,
       )
     end


### PR DESCRIPTION
# Goal
Pivotal Tracker: [#172383677](https://www.pivotaltracker.com/story/show/172383677)

In our demo meeting on April 17th, it was generally agreed that providing the ability to change a user's password presented a number of unacceptable security concerns.

This branch removes the ability to change a user's password. AU will instead use our tool to update a user's email if necessary and then instruct the student to use the standard Canvas password reset procedure.

## Implementation
I deleted a bunch of stuff. Look at all that red. Ain't it beautiful.

## Demo
**Before**
![edit_user_modal_old_2_column](https://user-images.githubusercontent.com/6520489/79614337-882c4b80-80bd-11ea-98c5-4c03dcd77a36.png)

**Without Password Field**
![edit_user_modal_2_column_with_password](https://user-images.githubusercontent.com/6520489/79614791-89aa4380-80be-11ea-9282-819cdd5b3639.png)

**After**
![edit_user_modal_full_width](https://user-images.githubusercontent.com/6520489/79614340-8bbfd280-80bd-11ea-969a-3819b97c789d.png)

![edit_user_modal_narrow_width](https://user-images.githubusercontent.com/6520489/79614346-8d899600-80bd-11ea-8705-56581a1ad1df.png)