### PR TITLE
Add Loading Indicators

### DIFF
--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -16,6 +16,7 @@ const select = state => ({
   previousPageAvailable: state.application.previousPageAvailable,
   nextPageAvailable: state.application.nextPageAvailable,
   isSearching: state.application.isSearching,
+  isUpdatingUser: state.application.isUpdatingUser,
 });
 
 export class SearchPage extends React.Component {
@@ -26,6 +27,7 @@ export class SearchPage extends React.Component {
     previousPageAvailable: PropTypes.bool,
     nextPageAvailable: PropTypes.bool,
     isSearching: PropTypes.bool,
+    isUpdatingUser: PropTypes.bool,
   };
 
   constructor() {
@@ -65,6 +67,7 @@ export class SearchPage extends React.Component {
       previousPageAvailable,
       nextPageAvailable,
       isSearching,
+      isUpdatingUser,
     } = this.props;
     const { inputSearchTerm, resultsSearchTerm, hasSearched } = this.state;
     const renderedUsers = matchingUsers.map(user => (
@@ -98,12 +101,12 @@ export class SearchPage extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {isSearching ? null : renderedUsers}
+              {(isSearching || isUpdatingUser) ? null : renderedUsers}
             </tbody>
           </table>
         </div>
 
-        { isSearching && <Loader /> }
+        { (isSearching || isUpdatingUser) && <Loader /> }
 
         { !hasSearched && <StartSearching /> }
 

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -41,6 +41,12 @@ export class SearchPage extends React.Component {
     this.minSearchTermLength = 3;
   }
 
+  isLoading() {
+    const { isSearching, isUpdatingUser } = this.props;
+
+    return isSearching || isUpdatingUser;
+  }
+
   updateInputSearchTerm(event) {
     this.setState({ inputSearchTerm: event.target.value });
   }
@@ -66,8 +72,6 @@ export class SearchPage extends React.Component {
       currentPage,
       previousPageAvailable,
       nextPageAvailable,
-      isSearching,
-      isUpdatingUser,
     } = this.props;
     const { inputSearchTerm, resultsSearchTerm, hasSearched } = this.state;
     const renderedUsers = matchingUsers.map(user => (
@@ -101,17 +105,17 @@ export class SearchPage extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {(isSearching || isUpdatingUser) ? null : renderedUsers}
+              {this.isLoading() ? null : renderedUsers}
             </tbody>
           </table>
         </div>
 
-        { (isSearching || isUpdatingUser) && <Loader /> }
+        { this.isLoading() && <Loader /> }
 
         { !hasSearched && <StartSearching /> }
 
         {
-          !isSearching
+          !this.isLoading()
           && hasSearched
           && _.isEmpty(matchingUsers)
           && <NoSearchResults searchTerm={resultsSearchTerm} />

--- a/client/apps/user_tool/components/main/search_page.jsx
+++ b/client/apps/user_tool/components/main/search_page.jsx
@@ -8,12 +8,14 @@ import UserSearchResult from './user_search_result';
 import StartSearching from './start_searching';
 import NoSearchResults from './no_search_results';
 import Pagination from '../../../../common/components/common/pagination';
+import Loader from '../../../../libs/components/loader';
 
 const select = state => ({
   matchingUsers: state.application.matchingUsers,
   currentPage: state.application.currentPage,
   previousPageAvailable: state.application.previousPageAvailable,
   nextPageAvailable: state.application.nextPageAvailable,
+  isSearching: state.application.isSearching,
 });
 
 export class SearchPage extends React.Component {
@@ -23,6 +25,7 @@ export class SearchPage extends React.Component {
     currentPage: PropTypes.number.isRequired,
     previousPageAvailable: PropTypes.bool,
     nextPageAvailable: PropTypes.bool,
+    isSearching: PropTypes.bool,
   };
 
   constructor() {
@@ -60,7 +63,8 @@ export class SearchPage extends React.Component {
       matchingUsers,
       currentPage,
       previousPageAvailable,
-      nextPageAvailable
+      nextPageAvailable,
+      isSearching,
     } = this.props;
     const { inputSearchTerm, resultsSearchTerm, hasSearched } = this.state;
     const renderedUsers = matchingUsers.map(user => (
@@ -94,15 +98,18 @@ export class SearchPage extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {renderedUsers}
+              {isSearching ? null : renderedUsers}
             </tbody>
           </table>
         </div>
 
+        { isSearching && <Loader /> }
+
         { !hasSearched && <StartSearching /> }
 
         {
-          hasSearched
+          !isSearching
+          && hasSearched
           && _.isEmpty(matchingUsers)
           && <NoSearchResults searchTerm={resultsSearchTerm} />
         }

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 
 import { SearchPage } from './search_page';
+import Loader from '../../../../libs/components/loader';
 
 jest.mock('./edit_user_modal');
 
@@ -64,6 +65,17 @@ describe('SearchPage', () => {
       expect(props.searchForAccountUsers).toHaveBeenCalledWith(
         searchTerm,
       );
+    });
+
+    it('displays the loading indicator', () => {
+      const searchPage = shallow(<SearchPage
+        matchingUsers={props.matchingUsers}
+        searchForAccountUsers={props.searchForAccountUsers}
+        currentPage={props.currentPage}
+        isSearching
+      />);
+
+      expect(searchPage.contains(<Loader />)).toEqual(true);
     });
   });
 

--- a/client/apps/user_tool/components/main/search_page.spec.jsx
+++ b/client/apps/user_tool/components/main/search_page.spec.jsx
@@ -177,4 +177,17 @@ describe('SearchPage', () => {
       );
     });
   });
+
+  describe('when a user is being updated', () => {
+    it('displays the loading indicator', () => {
+      const searchPage = shallow(<SearchPage
+        matchingUsers={props.matchingUsers}
+        searchForAccountUsers={props.searchForAccountUsers}
+        currentPage={props.currentPage}
+        isUpdatingUser
+      />);
+
+      expect(searchPage.contains(<Loader />)).toEqual(true);
+    });
+  });
 });

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -1,7 +1,11 @@
 import { Constants as ApplicationConstants } from '../actions/application';
 
 const defaultPage = 1;
-const initialState = () => ({ matchingUsers: [], currentPage: defaultPage });
+const initialState = () => ({
+  matchingUsers: [],
+  currentPage: defaultPage,
+  isSearching: false,
+});
 
 export default (state = initialState(), action) => {
   switch (action.type) {
@@ -9,7 +13,7 @@ export default (state = initialState(), action) => {
     case ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS: {
       const currentPage = action.params.page || defaultPage;
 
-      return { ...state, currentPage };
+      return { ...state, currentPage, isSearching: true };
     }
 
     case ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE: {
@@ -23,7 +27,8 @@ export default (state = initialState(), action) => {
         ...state,
         matchingUsers,
         previousPageAvailable,
-        nextPageAvailable
+        nextPageAvailable,
+        isSearching: false,
       };
     }
 

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -5,6 +5,7 @@ const initialState = () => ({
   matchingUsers: [],
   currentPage: defaultPage,
   isSearching: false,
+  isUpdatingUser: false
 });
 
 export default (state = initialState(), action) => {
@@ -32,6 +33,10 @@ export default (state = initialState(), action) => {
       };
     }
 
+    case ApplicationConstants.UPDATE_USER: {
+      return { ...state, isUpdatingUser: true };
+    }
+
     case ApplicationConstants.UPDATE_USER_DONE: {
       const {
         id,
@@ -55,7 +60,7 @@ export default (state = initialState(), action) => {
         return user;
       });
 
-      return { ...state, matchingUsers };
+      return { ...state, matchingUsers, isUpdatingUser: false };
     }
 
     default:

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -6,6 +6,7 @@ describe('application reducer', () => {
     matchingUsers: (opts && opts.matchingUsers) || [],
     currentPage: (opts && opts.currentPage) || 1,
     isSearching: (opts && opts.isSearching) || false,
+    isUpdatingUser: (opts && opts.isUpdatingUser) || false,
   });
 
   describe('initial state', () => {
@@ -121,6 +122,19 @@ describe('application reducer', () => {
     });
   });
 
+  describe('UPDATE_USER', () => {
+    it('sets isUpdatingUser to true', () => {
+      const action = {
+        type: ApplicationConstants.UPDATE_USER,
+        params: {},
+      };
+
+      const state = applicationReducer(initialState(), action);
+
+      expect(state.isUpdatingUser).toEqual(true);
+    });
+  });
+
   describe('UPDATE_USER_DONE', () => {
     it('updates the user in matchingUsers', () => {
       const matchingUsers = [
@@ -161,6 +175,20 @@ describe('application reducer', () => {
       const state = applicationReducer({ ...initialState(), matchingUsers }, action);
 
       expect(state.matchingUsers[1]).toEqual(updatedUser);
+    });
+
+    it('sets isUpdatingUser to false', () => {
+      const action = {
+        type: ApplicationConstants.UPDATE_USER_DONE,
+        payload: {},
+      };
+
+      const state = applicationReducer(
+        initialState({ isUpdatingUser: true }),
+        action,
+      );
+
+      expect(state.isUpdatingUser).toEqual(false);
     });
   });
 });

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -2,7 +2,11 @@ import applicationReducer from './application';
 import { Constants as ApplicationConstants } from '../actions/application';
 
 describe('application reducer', () => {
-  const initialState = () => ({ matchingUsers: [], currentPage: 1 });
+  const initialState = opts => ({
+    matchingUsers: (opts && opts.matchingUsers) || [],
+    currentPage: (opts && opts.currentPage) || 1,
+    isSearching: (opts && opts.isSearching) || false,
+  });
 
   describe('initial state', () => {
     it('returns empty state', () => {
@@ -23,6 +27,17 @@ describe('application reducer', () => {
       const state = applicationReducer(initialState(), action);
 
       expect(state.currentPage).toEqual(page);
+    });
+
+    it('sets isSearching to true', () => {
+      const action = {
+        type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS,
+        params: {},
+      };
+
+      const state = applicationReducer(initialState(), action);
+
+      expect(state.isSearching).toEqual(true);
     });
 
     describe('when no page is given', () => {
@@ -78,6 +93,17 @@ describe('application reducer', () => {
       const state = applicationReducer(initialState(), action);
 
       expect(state.nextPageAvailable).toEqual(nextPageAvailable);
+    });
+
+    it('sets isSearching to false', () => {
+      const action = {
+        type: ApplicationConstants.SEARCH_FOR_ACCOUNT_USERS_DONE,
+        payload: {},
+      };
+
+      const state = applicationReducer(initialState({ isSearching: true }), action);
+
+      expect(state.isSearching).toEqual(false);
     });
 
     describe('when the action payload contains a falsey value for matching_users', () => {

--- a/client/apps/user_tool/styles/styles.scss
+++ b/client/apps/user_tool/styles/styles.scss
@@ -7,6 +7,7 @@
 @import "partials/inputs";
 @import "partials/modal";
 @import "partials/table";
+@import "../../../libs/styles/common/partials/loader";
 // ...
 
 // Third-party


### PR DESCRIPTION
# Goal
Pivotal Tracker: [#172251053](https://www.pivotaltracker.com/story/show/172251053), [#172251090](https://www.pivotaltracker.com/story/show/172251090)

This branch adds loading indicators that are displayed while a search request is executing or while an update request is executing.

We also plan on adding a flash message indicating when a user is updated successfully, but that will happen in a separate pull request.

## Tradeoffs & Alternatives
The loader I used is pretty basic. I used it because it was already in the project and it suits our purposes well enough. If we want to use a fancier Atomic Jolt loader; we could switch to that, but I wasn't sure it was worth the effort

## Demo
![loaders](https://user-images.githubusercontent.com/6520489/79801854-20277080-831c-11ea-96e0-06565fe28e64.gif)