### PR TITLE
Add Missing Default Application State

### DIFF
--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -4,6 +4,8 @@ const defaultPage = 1;
 const initialState = () => ({
   matchingUsers: [],
   currentPage: defaultPage,
+  previousPageAvailable: false,
+  nextPageAvailable: false,
   isSearching: false,
   isUpdatingUser: false
 });

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -5,6 +5,8 @@ describe('application reducer', () => {
   const initialState = opts => ({
     matchingUsers: (opts && opts.matchingUsers) || [],
     currentPage: (opts && opts.currentPage) || 1,
+    previousPageAvailable: (opts && opts.previousPageAvailable) || false,
+    nextPageAvailable: (opts && opts.nextPageAvailable) || false,
     isSearching: (opts && opts.isSearching) || false,
     isUpdatingUser: (opts && opts.isUpdatingUser) || false,
   });


### PR DESCRIPTION
It isn't strictly necessary that these values have defaults because `undefined` works just as well as `false` for how we're using them, but I think it's clearer to define all of the default state up front.