### PR TITLE
Disable Edit User Form for Account Admins

### DIFF
--- a/app/controllers/api/canvas_account_users_controller.rb
+++ b/app/controllers/api/canvas_account_users_controller.rb
@@ -22,6 +22,17 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     )
   end
 
+  # This action only shows users who are members of the Canvas account given in the LTI launch.
+  # Users from sub-accounts of that account are also shown.
+  # This action shows additional user information that is not included in the index action response.
+  def show
+    user = search_for_users_on_canvas(params[:id]).first
+
+    user.merge!(is_account_admin: user_being_edited_is_account_admin?)
+
+    render(json: user, status: :ok)
+  end
+
   # This action can only update users who are members of the Canvas account given in the LTI launch.
   # Users from sub-accounts of that account can also be updated.
   def update
@@ -84,17 +95,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
   end
 
   def validate_user_being_changed_is_not_admin
-    list_accounts_response = canvas_api.proxy(
-      "LIST_ACCOUNTS",
-      { as_user_id: params[:id] },
-    )
-
-    # The [Canvas API docs](https://canvas.instructure.com/doc/api/accounts.html#method.accounts.index)
-    # state that "only account admins can view the accounts that they are in."
-    # Thus, we are assuming that a non-empty response means the user is an account admin somewhere.
-    user_is_account_admin = list_accounts_response.present?
-
-    if user_is_account_admin
+    if user_being_edited_is_account_admin?
       user_not_authorized(
         "The user you are trying to update has an admin role in one or more " \
         "accounts. This tool does not support updating admin users. Please contact " \
@@ -115,6 +116,18 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     canvas_url = "accounts/#{jwt_lms_account_id}/users?#{query_params.to_query}"
 
     canvas_api.api_get_request(canvas_url)
+  end
+
+  def user_being_edited_is_account_admin?
+    @list_accounts_response ||= canvas_api.proxy(
+      "LIST_ACCOUNTS",
+      { as_user_id: params[:id] },
+    )
+
+    # The [Canvas API docs](https://canvas.instructure.com/doc/api/accounts.html#method.accounts.index)
+    # state that "only account admins can view the accounts that they are in."
+    # Thus, we are assuming that a non-empty response means the user is an account admin somewhere.
+    @list_accounts_response.present?
   end
 
   def edit_user_on_canvas

--- a/app/controllers/api/canvas_account_users_controller.rb
+++ b/app/controllers/api/canvas_account_users_controller.rb
@@ -28,7 +28,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
   def show
     user = search_for_users_on_canvas(params[:id]).first
 
-    user[:is_account_admin] = user_being_edited_is_account_admin?
+    user[:is_account_admin] = user_being_changed_is_account_admin?
 
     render(json: user, status: :ok)
   end
@@ -63,7 +63,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
         login_id: edit_user_login_response["unique_id"],
         sis_user_id: edit_user_login_response["sis_user_id"],
         email: edit_user_response["email"],
-        is_account_admin: user_being_edited_is_account_admin?,
+        is_account_admin: user_being_changed_is_account_admin?,
       },
       status: :ok,
     )
@@ -96,7 +96,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
   end
 
   def validate_user_being_changed_is_not_admin
-    if user_being_edited_is_account_admin?
+    if user_being_changed_is_account_admin?
       user_not_authorized(
         "The user you are trying to update has an admin role in one or more " \
         "accounts. This tool does not support updating admin users. Please contact " \
@@ -119,7 +119,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     canvas_api.api_get_request(canvas_url)
   end
 
-  def user_being_edited_is_account_admin?
+  def user_being_changed_is_account_admin?
     @list_accounts_response ||= canvas_api.proxy(
       "LIST_ACCOUNTS",
       { as_user_id: params[:id] },

--- a/app/controllers/api/canvas_account_users_controller.rb
+++ b/app/controllers/api/canvas_account_users_controller.rb
@@ -63,6 +63,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
         login_id: edit_user_login_response["unique_id"],
         sis_user_id: edit_user_login_response["sis_user_id"],
         email: edit_user_response["email"],
+        is_account_admin: user_being_edited_is_account_admin?,
       },
       status: :ok,
     )

--- a/app/controllers/api/canvas_account_users_controller.rb
+++ b/app/controllers/api/canvas_account_users_controller.rb
@@ -28,7 +28,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
   def show
     user = search_for_users_on_canvas(params[:id]).first
 
-    user.merge!(is_account_admin: user_being_edited_is_account_admin?)
+    user[:is_account_admin] = user_being_edited_is_account_admin?
 
     render(json: user, status: :ok)
   end

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -5,7 +5,7 @@ import Network from 'atomic-fuel/libs/constants/network';
 const actions = [];
 
 // Actions that make an api request
-const requests = ['SEARCH_FOR_ACCOUNT_USERS', 'UPDATE_USER'];
+const requests = ['SEARCH_FOR_ACCOUNT_USERS', 'GET_ACCOUNT_USER', 'UPDATE_USER'];
 
 export const Constants = wrapper(actions, requests);
 
@@ -17,6 +17,12 @@ export const searchForAccountUsers = (searchTerm, page) => ({
     search_term: searchTerm,
     page,
   },
+});
+
+export const getAccountUser = (userId) => ({
+  type: Constants.GET_ACCOUNT_USER,
+  method: Network.GET,
+  url: `api/canvas_account_users/${userId}`,
 });
 
 export const updateUser = (userId, userAttributes) => ({

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -5,7 +5,7 @@ import Network from 'atomic-fuel/libs/constants/network';
 const actions = [];
 
 // Actions that make an api request
-const requests = ['SEARCH_FOR_ACCOUNT_USERS', 'GET_ACCOUNT_USER', 'UPDATE_USER'];
+const requests = ['SEARCH_FOR_ACCOUNT_USERS', 'GET_ACCOUNT_USER', 'UPDATE_ACCOUNT_USER'];
 
 export const Constants = wrapper(actions, requests);
 
@@ -25,8 +25,8 @@ export const getAccountUser = (userId) => ({
   url: `api/canvas_account_users/${userId}`,
 });
 
-export const updateUser = (userId, userAttributes) => ({
-  type: Constants.UPDATE_USER,
+export const updateAccountUser = (userId, userAttributes) => ({
+  type: Constants.UPDATE_ACCOUNT_USER,
   method: Network.PUT,
   url: `api/canvas_account_users/${userId}`,
   body: {

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -19,7 +19,7 @@ export const searchForAccountUsers = (searchTerm, page) => ({
   },
 });
 
-export const getAccountUser = (userId) => ({
+export const getAccountUser = userId => ({
   type: Constants.GET_ACCOUNT_USER,
   method: Network.GET,
   url: `api/canvas_account_users/${userId}`,

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -1,4 +1,4 @@
-import { searchForAccountUsers, updateUser } from './application';
+import { searchForAccountUsers, getAccountUser, updateUser } from './application';
 
 describe('application actions', () => {
   describe('searchForAccountUsers', () => {
@@ -34,6 +34,19 @@ describe('application actions', () => {
 
         expect(searchForAccountUsers(searchTerm, page)).toEqual(expectedAction);
       });
+    });
+  });
+
+  describe('getAccountUser', () => {
+    it('generates the correct action', () => {
+      const userId = 123;
+      const expectedAction = {
+        type: 'GET_ACCOUNT_USER',
+        method: 'get',
+        url: `api/canvas_account_users/${userId}`,
+      };
+
+      expect(getAccountUser(userId)).toEqual(expectedAction);
     });
   });
 

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -1,4 +1,4 @@
-import { searchForAccountUsers, getAccountUser, updateUser } from './application';
+import { searchForAccountUsers, getAccountUser, updateAccountUser } from './application';
 
 describe('application actions', () => {
   describe('searchForAccountUsers', () => {
@@ -50,7 +50,7 @@ describe('application actions', () => {
     });
   });
 
-  describe('updateUser', () => {
+  describe('updateAccountUser', () => {
     const userId = 45;
     const userAttributes = {
       name: 'John Adams',
@@ -61,7 +61,7 @@ describe('application actions', () => {
 
     it('generates the correct action', () => {
       const expectedAction = {
-        type: 'UPDATE_USER',
+        type: 'UPDATE_ACCOUNT_USER',
         method: 'put',
         url: `api/canvas_account_users/${userId}`,
         body: {
@@ -74,7 +74,7 @@ describe('application actions', () => {
         },
       };
 
-      expect(updateUser(userId, userAttributes))
+      expect(updateAccountUser(userId, userAttributes))
         .toEqual(expectedAction);
     });
   });

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -38,8 +38,9 @@ exports[`EditUserModal renders the edit user modal 1`] = `
     </button>
   </div>
   <form>
-    <div
+    <fieldset
       className="modal__main"
+      disabled={false}
     >
       <div
         className="row"
@@ -117,7 +118,7 @@ exports[`EditUserModal renders the edit user modal 1`] = `
           </div>
         </div>
       </div>
-    </div>
+    </fieldset>
     <div
       className="modal__bottom"
     >
@@ -130,6 +131,7 @@ exports[`EditUserModal renders the edit user modal 1`] = `
       </button>
       <button
         className="btn btn--primary"
+        disabled={false}
         onClick={[Function]}
         type="submit"
       >
@@ -142,8 +144,9 @@ exports[`EditUserModal renders the edit user modal 1`] = `
 
 exports[`EditUserModal when the user clicks the Update button renders the changed attributes 1`] = `
 <form>
-  <div
+  <fieldset
     className="modal__main"
+    disabled={false}
   >
     <div
       className="row"
@@ -237,7 +240,7 @@ exports[`EditUserModal when the user clicks the Update button renders the change
         </div>
       </div>
     </div>
-  </div>
+  </fieldset>
   <div
     className="modal__bottom"
   >
@@ -253,6 +256,7 @@ exports[`EditUserModal when the user clicks the Update button renders the change
     </button>
     <button
       className="btn btn--primary is-green"
+      disabled={false}
       onClick={[Function]}
       type="submit"
     >

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import _ from 'lodash';
 import { connect } from 'react-redux';
-import { updateAccountUser } from '../../actions/application';
+import { getAccountUser, updateAccountUser } from '../../actions/application';
 
 const select = () => ({});
 
 export class EditUserModal extends React.Component {
   static propTypes = {
+    getAccountUser: PropTypes.func.isRequired,
     updateAccountUser: PropTypes.func.isRequired,
     isOpen: PropTypes.bool.isRequired,
     closeModal: PropTypes.func.isRequired,
@@ -29,12 +30,38 @@ export class EditUserModal extends React.Component {
     });
   }
 
+  static accountAdminErrorHTML() {
+    return (
+      <div className="errors">
+        <p>
+          The user you are trying to update has an admin role in one or more
+          accounts. This tool does not support updating admin users. Please contact
+          a higher-level administrator to edit this user.
+        </p>
+      </div>
+    );
+  }
+
   constructor(props) {
     super();
 
     this.state = EditUserModal.initialState(props);
 
     this.handleInputChange = this.handleInputChange.bind(this);
+  }
+
+  componentDidMount() {
+    const { getAccountUser:getUser, user } = this.props;
+
+    if (user.is_account_admin === undefined) {
+      getUser(user.id);
+    }
+  }
+
+  canEditUser() {
+    const { user } = this.props;
+
+    return !user.is_account_admin;
   }
 
   handleInputChange(event) {
@@ -111,6 +138,7 @@ export class EditUserModal extends React.Component {
           className={`btn ${submitButtonClasses}`}
           type="submit"
           onClick={event => this.handleSubmit(event)}
+          disabled={!this.canEditUser()}
         >
           {submitButtonText}
         </button>
@@ -137,8 +165,10 @@ export class EditUserModal extends React.Component {
           </button>
         </div>
 
+        { !this.canEditUser() && EditUserModal.accountAdminErrorHTML() }
+
         <form>
-          <div className="modal__main">
+          <fieldset className="modal__main" disabled={!this.canEditUser()}>
             <div className="row">
               <div className="column u-half">
                 <div className="input">
@@ -189,7 +219,7 @@ export class EditUserModal extends React.Component {
                 </div>
               </div>
             </div>
-          </div>
+          </fieldset>
           <div className="modal__bottom">
             { confirmingUpdates && (
               <p>Are you sure you want to apply the current changes to this user?</p>
@@ -203,4 +233,4 @@ export class EditUserModal extends React.Component {
   }
 }
 
-export default connect(select, { updateAccountUser })(EditUserModal);
+export default connect(select, { getAccountUser, updateAccountUser })(EditUserModal);

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import _ from 'lodash';
 import { connect } from 'react-redux';
-import { updateUser } from '../../actions/application';
+import { updateAccountUser } from '../../actions/application';
 
 const select = () => ({});
 
 export class EditUserModal extends React.Component {
   static propTypes = {
-    updateUser: PropTypes.func.isRequired,
+    updateAccountUser: PropTypes.func.isRequired,
     isOpen: PropTypes.bool.isRequired,
     closeModal: PropTypes.func.isRequired,
     user: PropTypes.object.isRequired,
@@ -52,7 +52,7 @@ export class EditUserModal extends React.Component {
   handleSubmit(event) {
     event.preventDefault();
 
-    const { user, updateUser:update, closeModal } = this.props;
+    const { user, updateAccountUser:update, closeModal } = this.props;
     const { confirmingUpdates, userForm } = this.state;
 
     if (confirmingUpdates) {
@@ -203,4 +203,4 @@ export class EditUserModal extends React.Component {
   }
 }
 
-export default connect(select, { updateUser })(EditUserModal);
+export default connect(select, { updateAccountUser })(EditUserModal);

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -32,7 +32,7 @@ export class EditUserModal extends React.Component {
 
   static accountAdminErrorHTML() {
     return (
-      <div className="errors">
+      <div className="messages error">
         <p>
           The user you are trying to update has an admin role in one or more
           accounts. This tool does not support updating admin users. Please contact

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -5,9 +5,11 @@ import { EditUserModal } from './edit_user_modal';
 
 describe('EditUserModal', () => {
   const props = {
+    getAccountUser: () => {},
     updateAccountUser: () => {},
     closeModal: () => {},
     user: {
+      id: '123',
       name: 'George Washington',
       email: 'countryfather@revolution.com',
       roles: ['admin', 'teacher'],
@@ -19,6 +21,7 @@ describe('EditUserModal', () => {
   it('renders the edit user modal', () => {
     const modal = shallow(
       <EditUserModal
+        getAccountUser={props.getAccountUser}
         updateAccountUser={props.updateAccountUser}
         isOpen
         closeModal={props.closeModal}
@@ -29,11 +32,77 @@ describe('EditUserModal', () => {
     expect(modal).toMatchSnapshot();
   });
 
+  describe('when the user has no is_account_admin attribute', () => {
+    it('calls the getAccountUser action', () => {
+      spyOn(props, 'getAccountUser');
+      shallow(
+        <EditUserModal
+          getAccountUser={props.getAccountUser}
+          updateAccountUser={props.updateAccountUser}
+          isOpen
+          closeModal={props.closeModal}
+          user={props.user}
+        />
+      );
+
+      expect(props.getAccountUser).toHaveBeenCalledWith(props.user.id);
+    });
+  });
+
+  describe('when the user has an is_account_admin attribute', () => {
+    it('does not call the getAccountUser action', () => {
+      spyOn(props, 'getAccountUser');
+      shallow(
+        <EditUserModal
+          getAccountUser={props.getAccountUser}
+          updateAccountUser={props.updateAccountUser}
+          isOpen
+          closeModal={props.closeModal}
+          user={{ ...props.user, is_account_admin: true }}
+        />
+      );
+
+      expect(props.getAccountUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the user is an account admin', () => {
+    const modal = shallow(
+      <EditUserModal
+        getAccountUser={props.getAccountUser}
+        updateAccountUser={props.updateAccountUser}
+        isOpen
+        closeModal={props.closeModal}
+        user={{ ...props.user, is_account_admin: true }}
+      />
+    );
+
+    it('displays an error message', () => {
+      const errorMessage = modal.find('.errors').text();
+
+      expect(errorMessage)
+        .toEqual(expect.stringContaining('user you are trying to update has an admin role'));
+    });
+
+    it('disables the submit button', () => {
+      const submitButton = modal.find('button[type="submit"]');
+
+      expect(submitButton.prop('disabled')).toBe(true);
+    });
+
+    it('disables the input fields', () => {
+      const fieldset = modal.find('fieldset');
+
+      expect(fieldset.prop('disabled')).toBe(true);
+    });
+  });
+
   describe('when the close/x button is clicked', () => {
     it('closes the modal', () => {
       spyOn(props, 'closeModal');
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
@@ -51,6 +120,7 @@ describe('EditUserModal', () => {
     it('resets the form to default values', () => {
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
@@ -81,6 +151,7 @@ describe('EditUserModal', () => {
     it('resets the submission button to "Update"', () => {
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
@@ -107,6 +178,7 @@ describe('EditUserModal', () => {
       spyOn(props, 'closeModal');
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
@@ -126,6 +198,7 @@ describe('EditUserModal', () => {
       spyOn(props, 'updateAccountUser');
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
@@ -169,6 +242,7 @@ describe('EditUserModal', () => {
     it('resets the submission button to "Update"', () => {
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
@@ -192,6 +266,7 @@ describe('EditUserModal', () => {
     it('the button text changes to "Confirm"', () => {
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
@@ -211,6 +286,7 @@ describe('EditUserModal', () => {
     it('displays the confirmation message', () => {
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
@@ -232,6 +308,7 @@ describe('EditUserModal', () => {
     it('renders the changed attributes', () => {
       const modal = shallow(
         <EditUserModal
+          getAccountUser={props.getAccountUser}
           updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -78,7 +78,7 @@ describe('EditUserModal', () => {
     );
 
     it('displays an error message', () => {
-      const errorMessage = modal.find('.errors').text();
+      const errorMessage = modal.find('.error').text();
 
       expect(errorMessage)
         .toEqual(expect.stringContaining('user you are trying to update has an admin role'));

--- a/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.spec.jsx
@@ -5,7 +5,7 @@ import { EditUserModal } from './edit_user_modal';
 
 describe('EditUserModal', () => {
   const props = {
-    updateUser: () => {},
+    updateAccountUser: () => {},
     closeModal: () => {},
     user: {
       name: 'George Washington',
@@ -19,7 +19,7 @@ describe('EditUserModal', () => {
   it('renders the edit user modal', () => {
     const modal = shallow(
       <EditUserModal
-        updateUser={props.updateUser}
+        updateAccountUser={props.updateAccountUser}
         isOpen
         closeModal={props.closeModal}
         user={props.user}
@@ -34,7 +34,7 @@ describe('EditUserModal', () => {
       spyOn(props, 'closeModal');
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}
@@ -51,7 +51,7 @@ describe('EditUserModal', () => {
     it('resets the form to default values', () => {
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}
@@ -81,7 +81,7 @@ describe('EditUserModal', () => {
     it('resets the submission button to "Update"', () => {
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}
@@ -107,7 +107,7 @@ describe('EditUserModal', () => {
       spyOn(props, 'closeModal');
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}
@@ -123,10 +123,10 @@ describe('EditUserModal', () => {
 
   describe('when the user updates, confirms and submits the form', () => {
     it('submits an update request', () => {
-      spyOn(props, 'updateUser');
+      spyOn(props, 'updateAccountUser');
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}
@@ -155,7 +155,7 @@ describe('EditUserModal', () => {
       // Click again to confirm.
       modal.find('button[type="submit"]').simulate('click', { preventDefault: () => {} });
 
-      expect(props.updateUser).toHaveBeenCalledWith(
+      expect(props.updateAccountUser).toHaveBeenCalledWith(
         props.user.id,
         {
           name: newName,
@@ -169,7 +169,7 @@ describe('EditUserModal', () => {
     it('resets the submission button to "Update"', () => {
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}
@@ -192,7 +192,7 @@ describe('EditUserModal', () => {
     it('the button text changes to "Confirm"', () => {
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}
@@ -211,7 +211,7 @@ describe('EditUserModal', () => {
     it('displays the confirmation message', () => {
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}
@@ -232,7 +232,7 @@ describe('EditUserModal', () => {
     it('renders the changed attributes', () => {
       const modal = shallow(
         <EditUserModal
-          updateUser={props.updateUser}
+          updateAccountUser={props.updateAccountUser}
           isOpen
           closeModal={props.closeModal}
           user={props.user}

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -33,11 +33,11 @@ export default (state = initialState(), action) => {
       };
     }
 
-    case ApplicationConstants.UPDATE_USER: {
+    case ApplicationConstants.UPDATE_ACCOUNT_USER: {
       return { ...state, isUpdatingUser: true };
     }
 
-    case ApplicationConstants.UPDATE_USER_DONE: {
+    case ApplicationConstants.UPDATE_ACCOUNT_USER_DONE: {
       const {
         id,
         name,

--- a/client/apps/user_tool/reducers/application.js
+++ b/client/apps/user_tool/reducers/application.js
@@ -8,6 +8,34 @@ const initialState = () => ({
   isUpdatingUser: false
 });
 
+const updateSingleUser = (state, payload) => {
+  const {
+    id,
+    name,
+    login_id:loginId,
+    sis_user_id:sisUserId,
+    email,
+    is_account_admin:isAccountAdmin,
+  } = payload;
+
+  const matchingUsers = state.matchingUsers.map((user) => {
+    if (user.id === Number(id)) {
+      return {
+        ...user,
+        name,
+        login_id: loginId,
+        sis_user_id: sisUserId,
+        email,
+        is_account_admin: isAccountAdmin,
+      };
+    }
+
+    return user;
+  });
+
+  return matchingUsers;
+};
+
 export default (state = initialState(), action) => {
   switch (action.type) {
 
@@ -33,32 +61,18 @@ export default (state = initialState(), action) => {
       };
     }
 
+    case ApplicationConstants.GET_ACCOUNT_USER_DONE: {
+      const matchingUsers = updateSingleUser(state, action.payload);
+
+      return { ...state, matchingUsers };
+    }
+
     case ApplicationConstants.UPDATE_ACCOUNT_USER: {
       return { ...state, isUpdatingUser: true };
     }
 
     case ApplicationConstants.UPDATE_ACCOUNT_USER_DONE: {
-      const {
-        id,
-        name,
-        login_id,
-        sis_user_id,
-        email
-      } = action.payload;
-
-      const matchingUsers = state.matchingUsers.map((user) => {
-        if (user.id === Number(id)) {
-          return {
-            ...user,
-            name,
-            login_id,
-            sis_user_id,
-            email
-          };
-        }
-
-        return user;
-      });
+      const matchingUsers = updateSingleUser(state, action.payload);
 
       return { ...state, matchingUsers, isUpdatingUser: false };
     }

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -122,6 +122,50 @@ describe('application reducer', () => {
     });
   });
 
+  describe('GET_ACCOUNT_USER_DONE', () => {
+    it('updates the user in matchingUsers', () => {
+      const matchingUsers = [
+        {
+          id: 1,
+          name: 'George Washington',
+          login_id: 'countryfather@revolution.com',
+          sis_user_id: 'george_123',
+          email: 'countryfather@revolution.com',
+        },
+        {
+          id: 2,
+          name: 'John Adams',
+          login_id: 'adamsforindependence@revolution.com',
+          sis_user_id: 'john_123',
+          email: 'adamsforindependence@revolution.com',
+        },
+        {
+          id: 3,
+          name: 'Thomas Jefferson',
+          login_id: 'idodeclare@revolution.com',
+          sis_user_id: 'thomas_123',
+          email: 'idodeclare@revolution.com',
+        },
+      ];
+      const fetchedUser = {
+        id: 2,
+        name: 'John Adams',
+        login_id: 'adamsforindependence@revolution.com',
+        sis_user_id: 'john_123',
+        email: 'adamsforindependence@revolution.com',
+        is_account_admin: true,
+      };
+      const action = {
+        type: ApplicationConstants.GET_ACCOUNT_USER_DONE,
+        payload: fetchedUser,
+      };
+
+      const state = applicationReducer({ ...initialState(), matchingUsers }, action);
+
+      expect(state.matchingUsers[1]).toEqual(fetchedUser);
+    });
+  });
+
   describe('UPDATE_ACCOUNT_USER', () => {
     it('sets isUpdatingUser to true', () => {
       const action = {

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -162,7 +162,7 @@ describe('application reducer', () => {
         payload: fetchedUser,
       };
 
-      const state = applicationReducer({ ...initialState(), matchingUsers }, action);
+      const state = applicationReducer(initialState({ matchingUsers }), action);
 
       expect(state.matchingUsers[1]).toEqual(fetchedUser);
     });
@@ -218,7 +218,7 @@ describe('application reducer', () => {
         payload: updatedUser,
       };
 
-      const state = applicationReducer({ ...initialState(), matchingUsers }, action);
+      const state = applicationReducer(initialState({ matchingUsers }), action);
 
       expect(state.matchingUsers[1]).toEqual(updatedUser);
     });

--- a/client/apps/user_tool/reducers/application.spec.js
+++ b/client/apps/user_tool/reducers/application.spec.js
@@ -122,10 +122,10 @@ describe('application reducer', () => {
     });
   });
 
-  describe('UPDATE_USER', () => {
+  describe('UPDATE_ACCOUNT_USER', () => {
     it('sets isUpdatingUser to true', () => {
       const action = {
-        type: ApplicationConstants.UPDATE_USER,
+        type: ApplicationConstants.UPDATE_ACCOUNT_USER,
         params: {},
       };
 
@@ -135,7 +135,7 @@ describe('application reducer', () => {
     });
   });
 
-  describe('UPDATE_USER_DONE', () => {
+  describe('UPDATE_ACCOUNT_USER_DONE', () => {
     it('updates the user in matchingUsers', () => {
       const matchingUsers = [
         {
@@ -168,7 +168,7 @@ describe('application reducer', () => {
         email: 'adamsforindependence@revolution.com'
       };
       const action = {
-        type: ApplicationConstants.UPDATE_USER_DONE,
+        type: ApplicationConstants.UPDATE_ACCOUNT_USER_DONE,
         payload: updatedUser,
       };
 
@@ -179,7 +179,7 @@ describe('application reducer', () => {
 
     it('sets isUpdatingUser to false', () => {
       const action = {
-        type: ApplicationConstants.UPDATE_USER_DONE,
+        type: ApplicationConstants.UPDATE_ACCOUNT_USER_DONE,
         payload: {},
       };
 

--- a/client/apps/user_tool/reducers/success_messages.js
+++ b/client/apps/user_tool/reducers/success_messages.js
@@ -9,7 +9,7 @@ export default (state = initialState(), action) => {
       return [];
     }
 
-    case ApplicationConstants.UPDATE_USER_DONE: {
+    case ApplicationConstants.UPDATE_ACCOUNT_USER_DONE: {
       if (!action.error) {
         return [...state, 'User updated successfully.'];
       }

--- a/client/apps/user_tool/reducers/success_messages.spec.js
+++ b/client/apps/user_tool/reducers/success_messages.spec.js
@@ -25,11 +25,11 @@ describe('success messages reducer', () => {
     });
   });
 
-  describe('UPDATE_USER_DONE', () => {
+  describe('UPDATE_ACCOUNT_USER_DONE', () => {
     describe('when the action has no errors', () => {
       it('adds a success message to state', () => {
         const action = {
-          type: ApplicationConstants.UPDATE_USER_DONE,
+          type: ApplicationConstants.UPDATE_ACCOUNT_USER_DONE,
           payload: {},
         };
 
@@ -42,7 +42,7 @@ describe('success messages reducer', () => {
     describe('when the action has an error', () => {
       it('does not add a success message to state', () => {
         const action = {
-          type: ApplicationConstants.UPDATE_USER_DONE,
+          type: ApplicationConstants.UPDATE_ACCOUNT_USER_DONE,
           payload: {},
           error: { message: 'Something went wrong.' },
         };

--- a/client/apps/user_tool/styles/partials/_errors.scss
+++ b/client/apps/user_tool/styles/partials/_errors.scss
@@ -23,6 +23,12 @@
     }
   }
 
+  p{
+    color: $white;
+    @include bold;
+    font-size: 1.4rem;
+  }
+
   ul{
     flex: 1;
     margin: 0 1.2rem 0 0;

--- a/client/apps/user_tool/styles/partials/_inputs.scss
+++ b/client/apps/user_tool/styles/partials/_inputs.scss
@@ -142,6 +142,13 @@
   &:focus{
     outline: thin dotted $blue;
   }
+  &:disabled{
+    opacity: 0.65;
+
+    &:hover{
+      cursor: not-allowed;
+    }
+  }
 }
 
 .btn--primary{

--- a/client/apps/user_tool/styles/partials/_modal.scss
+++ b/client/apps/user_tool/styles/partials/_modal.scss
@@ -60,6 +60,7 @@
 }
 
 .modal__main{
+  border: none;
   padding: 1.6rem 1.6rem 0.8rem;
 
   .column{

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
 
     resources :canvas_accounts, only: [:index]
     # This endpoint provides access to users belonging to the Canvas account associated with the LTI launch.
-    resources :canvas_account_users, only: [:index, :update]
+    resources :canvas_account_users, only: [:index, :show, :update]
 
     resources :testing_centers_accounts
     resources :scorm_courses do

--- a/spec/controllers/api/canvas_account_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_account_users_controller_spec.rb
@@ -235,6 +235,12 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
       expect(JSON.parse(response.body)["email"]).to eq(params[:user][:email])
     end
 
+    it "returns whether the user is an account admin" do
+      response = put(:update, params: params)
+
+      expect(JSON.parse(response.body)["is_account_admin"]).to eq(false)
+    end
+
     it "creates a CanvasUserChange with the no failed attributes" do
       allow(CanvasUserChange).to receive(:create_by_diffing_attrs!)
 
@@ -248,6 +254,20 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
           new_attrs: params[:user],
           failed_attrs: [],
         )
+    end
+
+    context "when the user is an account admin" do
+      before do
+        allow_any_instance_of(LMS::Canvas).to receive(:proxy).
+          with("LIST_ACCOUNTS", anything).
+          and_return([{ "id" => 123, "name" => "Some Account" }])
+      end
+
+      it "returns true for is_account_admin" do
+        response = get(:show, params: params)
+
+        expect(JSON.parse(response.body)["is_account_admin"]).to eq(true)
+      end
     end
 
     context "when the user is not in the admin's account or sub-account" do


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#172383513](https://www.pivotaltracker.com/story/show/172383513)

Right now, we don't allow editing account admins. If someone tries to edit an account admin, the request is rejected on the back-end and an error message is returned. A better user experience would be to prevent the user from submitting the edit form for an account admin in the first place. This branch adds that functionality. 

## Implementation
In order to determine whether or not a given user is an account admin, I added a `show` action to the `CanvasAccountUsers` controller. I considered adding an `is_user_account_admin` action or something like that to the controller. Adding a `show` action seemed more predictable and user friendly to me though. It's certainly more RESTful.

To display the error message for admin users, we do the following. When the edit user modal mounts, we check if the user prop has an `is_account_admin` attribute. If it doesn't, we make an API call to the back-end to get it. Once we have that attribute, if a user is an account admin, we disable the edit form and display an error message. If a full 10 search results are returned, we end up making 10 API calls to the back-end. This isn't awesome, but I think it's acceptable because it's all happening in the background.

## Demo
![account_admin_error_message](https://user-images.githubusercontent.com/6520489/80026621-aae4a880-849f-11ea-98bc-c1b27d6f9d66.gif)

If a user opens an edit modal quickly enough, they might view the form before it's updated and disabled.
![account_admin_error_message_delayed](https://user-images.githubusercontent.com/6520489/80026618-a8824e80-849f-11ea-9e2a-c12aba4f728c.gif)