### PR TITLE
Add aria-live Announcements

### DIFF
--- a/client/apps/user_tool/components/layout/__snapshots__/errors.spec.jsx.snap
+++ b/client/apps/user_tool/components/layout/__snapshots__/errors.spec.jsx.snap
@@ -2,32 +2,44 @@
 
 exports[`Errors renders the errors 1`] = `
 <div
-  className="messages error"
+  aria-live="assertive"
+  id="errors"
 >
-  <ul>
-    <li
-      key="0"
-    >
-      Something went wrong.
-    </li>
-    <li
-      key="1"
-    >
-      A terrible thing happened.
-    </li>
-  </ul>
-  <button
-    aria-label="clear errors"
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    type="button"
+  <div
+    className="messages error"
   >
-    <i
-      aria-hidden="true"
-      className="material-icons"
+    <ul>
+      <li
+        key="0"
+      >
+        Something went wrong.
+      </li>
+      <li
+        key="1"
+      >
+        A terrible thing happened.
+      </li>
+    </ul>
+    <button
+      aria-label="clear errors"
+      onClick={[Function]}
+      onKeyPress={[Function]}
+      type="button"
     >
-      clear
-    </i>
-  </button>
+      <i
+        aria-hidden="true"
+        className="material-icons"
+      >
+        clear
+      </i>
+    </button>
+  </div>
 </div>
+`;
+
+exports[`Errors when there are no errors only renders the outer div 1`] = `
+<div
+  aria-live="assertive"
+  id="errors"
+/>
 `;

--- a/client/apps/user_tool/components/layout/__snapshots__/success_messages.spec.jsx.snap
+++ b/client/apps/user_tool/components/layout/__snapshots__/success_messages.spec.jsx.snap
@@ -2,14 +2,26 @@
 
 exports[`SuccessMessages renders the messages 1`] = `
 <div
-  className="messages success"
+  aria-live="polite"
+  id="success-messages"
 >
-  <ul>
-    <li
-      key="0"
-    >
-      User updated successfully.
-    </li>
-  </ul>
+  <div
+    className="messages success"
+  >
+    <ul>
+      <li
+        key="0"
+      >
+        User updated successfully.
+      </li>
+    </ul>
+  </div>
 </div>
+`;
+
+exports[`SuccessMessages when there are no messages only renders the outer div 1`] = `
+<div
+  aria-live="polite"
+  id="success-messages"
+/>
 `;

--- a/client/apps/user_tool/components/layout/errors.jsx
+++ b/client/apps/user_tool/components/layout/errors.jsx
@@ -23,18 +23,20 @@ export class Errors extends React.Component {
   render() {
     const { clearErrors:clear, errors } = this.props;
 
-    if (_.isEmpty(errors)) { return false; }
-
     const errorMessages = _.map(errors,
       (error, index) => <li key={index}>{error.message}</li>
     );
 
     return (
-      <div className="messages error">
-        <ul>{errorMessages}</ul>
-        <button type="button" onClick={clear} onKeyPress={event => this.handleClearKeyPress(event)} aria-label="clear errors">
-          <i className="material-icons" aria-hidden="true">clear</i>
-        </button>
+      <div id="errors" aria-live="assertive">
+        { !_.isEmpty(errors) && (
+          <div className="messages error">
+            <ul>{errorMessages}</ul>
+            <button type="button" onClick={clear} onKeyPress={event => this.handleClearKeyPress(event)} aria-label="clear errors">
+              <i className="material-icons" aria-hidden="true">clear</i>
+            </button>
+          </div>
+        )}
       </div>
     );
   }

--- a/client/apps/user_tool/components/layout/errors.spec.jsx
+++ b/client/apps/user_tool/components/layout/errors.spec.jsx
@@ -22,13 +22,13 @@ describe('Errors', () => {
   });
 
   describe('when there are no errors', () => {
-    it('renders nothing', () => {
+    it('only renders the outer div', () => {
       const errors = shallow(<Errors
         clearErrors={props.clearErrors}
         errors={[]}
       />);
 
-      expect(errors.html()).toEqual(null);
+      expect(errors).toMatchSnapshot();
     });
   });
 

--- a/client/apps/user_tool/components/layout/success_messages.jsx
+++ b/client/apps/user_tool/components/layout/success_messages.jsx
@@ -26,15 +26,17 @@ export class SuccessMessages extends React.Component {
   render() {
     const { messages } = this.props;
 
-    if (_.isEmpty(messages)) { return false; }
-
     const renderedMessages = _.map(messages,
       (message, index) => <li key={index}>{message}</li>
     );
 
     return (
-      <div className="messages success">
-        <ul>{renderedMessages}</ul>
+      <div id="success-messages" aria-live="polite">
+        { !_.isEmpty(renderedMessages) && (
+          <div className="messages success">
+            <ul>{renderedMessages}</ul>
+          </div>
+        )}
       </div>
     );
   }

--- a/client/apps/user_tool/components/layout/success_messages.spec.jsx
+++ b/client/apps/user_tool/components/layout/success_messages.spec.jsx
@@ -19,13 +19,13 @@ describe('SuccessMessages', () => {
   });
 
   describe('when there are no messages', () => {
-    it('renders nothing', () => {
+    it('only renders the outer div', () => {
       const successMessages = shallow(<SuccessMessages
         clearSuccessMessages={props.clearSuccessMessages}
         messages={[]}
       />);
 
-      expect(successMessages.html()).toEqual(null);
+      expect(successMessages).toMatchSnapshot();
     });
   });
 });

--- a/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
+++ b/client/apps/user_tool/components/main/__snapshots__/edit_user_modal.spec.jsx.snap
@@ -121,6 +121,9 @@ exports[`EditUserModal renders the edit user modal 1`] = `
     <div
       className="modal__bottom"
     >
+      <p
+        aria-live="assertive"
+      />
       <button
         className="btn btn--outline"
         onClick={[Function]}
@@ -241,7 +244,9 @@ exports[`EditUserModal when the user clicks the Update button renders the change
   <div
     className="modal__bottom"
   >
-    <p>
+    <p
+      aria-live="assertive"
+    >
       Are you sure you want to apply the current changes to this user?
     </p>
     <button

--- a/client/apps/user_tool/components/main/edit_user_modal.jsx
+++ b/client/apps/user_tool/components/main/edit_user_modal.jsx
@@ -191,9 +191,11 @@ export class EditUserModal extends React.Component {
             </div>
           </div>
           <div className="modal__bottom">
-            { confirmingUpdates && (
-              <p>Are you sure you want to apply the current changes to this user?</p>
-            )}
+            <p aria-live="assertive">
+              { confirmingUpdates && (
+                'Are you sure you want to apply the current changes to this user?'
+              )}
+            </p>
 
             {this.renderButtons()}
           </div>


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#172295926](https://www.pivotaltracker.com/story/show/172295926)

This branch adds aria-live announcements for error messages, success messages and the confirmation message in the edit user modal.

## Implementation
The [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) state, "Assistive technologies will announce dynamic changes in the content of a live region. The live region must first be present (and usually empty), so that the browser and assistive technologies are aware of it. Any subsequent changes are then announced."

That's why, in each case, I arranged the code so there was always a node in the DOM with the `aria-live` attribute even if the node was empty.

## Demo
**Confirmation Message and Success Message**
![confirm_message_and_success_message](https://user-images.githubusercontent.com/6520489/80037830-9c06f180-84b1-11ea-8dc2-f62f1f5dec75.gif)

**Error Message**
![error_message](https://user-images.githubusercontent.com/6520489/80037850-a6c18680-84b1-11ea-8636-b8dfbb7ef6f6.gif)