### PR TITLE
Improve Canvas User Change Logging

### DIFF
--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -12,11 +12,12 @@ class CanvasUserChange < ApplicationRecord
     record_attrs = {
       admin_making_changes_lms_id: admin_making_changes_lms_id,
       user_being_changed_lms_id: user_being_changed_lms_id,
-      failed_attributes: failed_attrs,
+      # We only want to include an attribute in this list if it's changed.
+      failed_attributes: failed_attrs.select { |attr| attr_changed?(original_attrs, new_attrs, attr) },
     }
 
     [:name, :login_id, :sis_user_id, :email].each do |attr|
-      next if original_attrs[attr] == new_attrs[attr] || new_attrs[attr].nil?
+      next unless attr_changed?(original_attrs, new_attrs, attr)
 
       record_attrs[attr] = {
         previous_value: original_attrs[attr],
@@ -32,4 +33,9 @@ class CanvasUserChange < ApplicationRecord
     failed_attributes.present?
   end
   alias_method :failed_attrs?, :failed_attributes?
+
+  def self.attr_changed?(original_attrs, new_attrs, attr)
+    !new_attrs[attr].nil? && new_attrs[attr] != original_attrs[attr]
+  end
+  private_class_method :attr_changed?
 end

--- a/spec/models/canvas_user_change_spec.rb
+++ b/spec/models/canvas_user_change_spec.rb
@@ -133,6 +133,22 @@ RSpec.describe CanvasUserChange, type: :model do
       it "populates the failed_attributes field" do
         expect(@canvas_user_change.failed_attributes).to eq(["email"])
       end
+
+      context "but the attribute is unchanged" do
+        it "does not include that attribute in the failed_attributes field" do
+          new_attrs[:email] = original_attrs[:email]
+
+          canvas_user_change = described_class.create_by_diffing_attrs!(
+            admin_making_changes_lms_id: admin_id,
+            user_being_changed_lms_id: user_id,
+            original_attrs: original_attrs,
+            new_attrs: new_attrs,
+            failed_attrs: [:email, :login_id],
+          )
+
+          expect(canvas_user_change.failed_attributes).to eq(["login_id"])
+        end
+      end
     end
 
     context "when the record is invalid" do


### PR DESCRIPTION
This updates the `CanvasUserChange` model to only include an attribute in the `failed_attributes` list if the new value for that attribute was different from the original value. This will improve consistency between the `failed_attributes` list and the individual attribute fields; the individual attribute fields are only populated if the value is changed.

With the previous implementation, you could have `NULL` in an individual attribute field but then see that attribute in the `failed_attributes` list. 

![inconsistent_attributes](https://user-images.githubusercontent.com/6520489/80109470-c355d100-853a-11ea-89de-98b64f78c5a0.png)

This would happen in a scenario where the API request to Canvas to update that certain attribute failed, but the attribute wasn't changed. So the attribute was included in the `failed_attributes` list but the individual attribute field was left blank because the value didn't change. I find this potentially confusing. Now, you will only see an attribute in the `failed_attributes` list if it's corresponding individual attribute field is also populated. That individual field, of course, would have `success: false`.

![greater_consistency](https://user-images.githubusercontent.com/6520489/80109621-ec766180-853a-11ea-8dac-04860ade22d5.png)
(Notice the absence of `login_id`. That attribute is updated in the same API request as `sis_user_id`, but it isn't in the list of failed attributes because it wasn't changed.)

Hopefully, these changes will make the `CanvasUserChange` records more understandable.