### PR TITLE
Only Allow LTI Admins to Launch the User Tool

### DIFF
--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -83,6 +83,14 @@ module Concerns
       user
     end
 
+    # The User Tool requires the launching user to be an LTI admin in the current context.
+    def validate_user_is_admin_for_user_tool
+      if current_application_instance.lti_key == Application::USERTOOL
+        roles = params[:roles].split(",")
+        user_not_authorized if (roles & LTI::Roles::ADMIN_ROLES).blank?
+      end
+    end
+
     private
 
     def valid_timestamp?

--- a/app/controllers/lti_launches_controller.rb
+++ b/app/controllers/lti_launches_controller.rb
@@ -7,6 +7,7 @@ class LtiLaunchesController < ApplicationController
   layout "client"
 
   skip_before_action :verify_authenticity_token
+  before_action :validate_user_is_admin_for_user_tool, except: [:init, :launch]
   before_action :do_lti, except: [:init, :launch]
   before_action :setup, only: %i[show]
 


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#172182759](https://www.pivotaltracker.com/story/show/172182759)

If the launching user is not an LTI admin in the current context, we want to reject the LTI launch for the user tool.

The user tool is only intended to be used by account admins.

## Implementation
This branch adds a `before_action` to the LTI launch to verify if the user is an LTI admin when the user tool is being launched. If the user is not an admin in the account the tool is being launched from, they'll see an error page and the LTI request will return a `401 Unauthorized`.

To be clear, the user tool is not visible in the account menu unless the user is an account admin. To get to the tool, a non-admin would have to acquire the direct link somehow.

## Demo
Non-admins will see the following:
![image](https://user-images.githubusercontent.com/6520489/80408201-0a69fc00-8884-11ea-97ae-466b87176474.png)