### PR TITLE
Eliminate Unnecessary Canvas API Calls

### DIFF
--- a/app/models/canvas_user_change.rb
+++ b/app/models/canvas_user_change.rb
@@ -29,13 +29,12 @@ class CanvasUserChange < ApplicationRecord
     create!(record_attrs)
   end
 
+  def self.attr_changed?(original_attrs, new_attrs, attr)
+    !new_attrs[attr].nil? && new_attrs[attr] != original_attrs[attr]
+  end
+
   def failed_attributes?
     failed_attributes.present?
   end
   alias_method :failed_attrs?, :failed_attributes?
-
-  def self.attr_changed?(original_attrs, new_attrs, attr)
-    !new_attrs[attr].nil? && new_attrs[attr] != original_attrs[attr]
-  end
-  private_class_method :attr_changed?
 end

--- a/spec/controllers/api/canvas_account_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_account_users_controller_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
     let(:original_user) do
       {
         "id" => "412",
-        "name" => "John Adams",
+        "name" => "Old School John Adams",
         "login_id" => "adamsforindependence@greatbritain.com",
         "sis_user_id" => "old_john_123",
         "email" => "adamsforindependence@greatbritain.com",
@@ -440,6 +440,65 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
             new_attrs: params[:user],
             failed_attrs: [:login_id, :sis_user_id],
           )
+      end
+    end
+
+    context "when not updating the name or email of the user" do
+      before do
+        params[:user][:name] = original_user["name"]
+        params[:user][:email] = original_user["email"]
+      end
+
+      it "does not make the edit user call to the Canvas API" do
+        expect_any_instance_of(LMS::Canvas).to_not receive(:api_put_request).
+          with("users/#{params[:id]}", anything)
+
+        put(:update, format: :json, params: params)
+      end
+
+      it "returns the original user name" do
+        response = put(:update, params: params)
+
+        expect(JSON.parse(response.body)["name"]).to eq(original_user["name"])
+      end
+
+      it "returns the original user email" do
+        response = put(:update, params: params)
+
+        expect(JSON.parse(response.body)["email"]).to eq(original_user["email"])
+      end
+    end
+
+    context "when not updating the login_id or sis_user_id" do
+      before do
+        params[:user][:login_id] = original_user["login_id"]
+        params[:user][:sis_user_id] = original_user["sis_user_id"]
+      end
+
+      it "does not make the find user login call to the Canvas API" do
+        expect_any_instance_of(LMS::Canvas).to_not receive(:proxy).
+          with("LIST_USER_LOGINS_USERS", anything)
+
+        put(:update, format: :json, params: params)
+      end
+
+      it "does not make the edit user login call to the Canvas API" do
+        expect_any_instance_of(LMS::Canvas).to_not receive(:api_put_request).
+          with("accounts/#{lms_account_id}/logins/#{numeric_login_id}", anything)
+
+        put(:update, format: :json, params: params)
+      end
+
+      it "returns the original user login_id" do
+        response = put(:update, params: params)
+
+        expect(JSON.parse(response.body)["login_id"]).to eq(original_user["login_id"])
+      end
+
+      it "returns the original user sis_user_id" do
+        response = put(:update, params: params)
+
+        expect(JSON.parse(response.body)["sis_user_id"]).to eq(original_user["sis_user_id"])
       end
     end
   end

--- a/spec/models/canvas_user_change_spec.rb
+++ b/spec/models/canvas_user_change_spec.rb
@@ -166,7 +166,45 @@ RSpec.describe CanvasUserChange, type: :model do
     end
   end
 
-  describe ".failed_attributes?" do
+  describe ".attr_changed?" do
+    context "when the attribute has changed" do
+      it "returns true" do
+        changed = described_class.attr_changed?(
+          { name: "Name" },
+          { name: "New Name" },
+          :name,
+        )
+
+        expect(changed).to be true
+      end
+    end
+
+    context "when the attribute has not changed" do
+      it "returns false" do
+        changed = described_class.attr_changed?(
+          { name: "Name" },
+          { name: "Name" },
+          :name,
+        )
+
+        expect(changed).to be false
+      end
+    end
+
+    context "when the attribute is nil" do
+      it "returns false" do
+        changed = described_class.attr_changed?(
+          { name: "Name" },
+          {},
+          :name,
+        )
+
+        expect(changed).to be false
+      end
+    end
+  end
+
+  describe "#failed_attributes?" do
     context "when the failed_attributes field is nil" do
       let(:canvas_user_change) do
         FactoryBot.create(:canvas_user_change, failed_attributes: nil)


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#172477006](https://www.pivotaltracker.com/story/show/172477006)

When updating a user, we make multiple API requests to Canvas to update the various pieces of user data that the tool allows you to update. However, if, for example, you only want to update the name of a user, there are a couple of API requests that are unnecessary because they're for updating other user data.

This branch updates the logic in the `CanvasAccountUsersController` `update` action to only make those API calls when necessary. These changes have the potential to eliminate up to 2 of the 5 Canvas API calls made in the update action. (Technically, it could eliminate 3 calls, but that would only happen if none of the user data was changed. I don't see why that would occur during normal usage of the application.)

## Implementation

The `update` action is starting to get a little too complex and long for my liking. I considered multiple ways of potentially breaking it up, but I didn't come up with any possible solutions that didn't introduce additional complexities that made it not worth it from my perspective.