### PR TITLE
Remove Searching by User ID

### DIFF
--- a/app/controllers/api/canvas_account_users_controller.rb
+++ b/app/controllers/api/canvas_account_users_controller.rb
@@ -3,14 +3,17 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
 
   before_action :validate_token
   before_action :validate_current_user_lti_admin
-  before_action :fetch_original_user, only: [:update]
-  before_action :validate_user_being_changed_is_in_account, only: [:update]
+  # These two actions should be done together. We should always verify the fetched
+  # user is in the account because we're depending on the ID passed by the client.
+  before_action :fetch_canvas_user,
+    :validate_user_being_changed_is_in_account,
+    only: [:show, :update]
   before_action :validate_user_being_changed_is_not_admin, only: [:update]
 
   # This action only lists users who are members of the Canvas account given in the LTI launch.
   # Users from sub-accounts of that account are also included.
   def index
-    canvas_response = search_for_users_on_canvas(params[:search_term], params[:page])
+    canvas_response = search_for_users_in_account(params[:search_term], params[:page])
 
     render(
       json: {
@@ -26,11 +29,9 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
   # Users from sub-accounts of that account are also shown.
   # This action shows additional user information that is not included in the index action response.
   def show
-    user = search_for_users_on_canvas(params[:id]).first
+    @canvas_user[:is_account_admin] = user_being_changed_is_account_admin?
 
-    user[:is_account_admin] = user_being_changed_is_account_admin?
-
-    render(json: user, status: :ok)
+    render(json: @canvas_user, status: :ok)
   end
 
   # This action can only update users who are members of the Canvas account given in the LTI launch.
@@ -61,10 +62,10 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     render(
       json: {
         id: params[:id],
-        name: edit_user_response&.[]("name") || @original_user[:name],
-        login_id: edit_user_login_response&.[]("unique_id") || @original_user[:login_id],
-        sis_user_id: edit_user_login_response&.[]("sis_user_id") || @original_user[:sis_user_id],
-        email: edit_user_response&.[]("email") || @original_user[:email],
+        name: edit_user_response&.[]("name") || @canvas_user[:name],
+        login_id: edit_user_login_response&.[]("unique_id") || @canvas_user[:login_id],
+        sis_user_id: edit_user_login_response&.[]("sis_user_id") || @canvas_user[:sis_user_id],
+        email: edit_user_response&.[]("email") || @canvas_user[:email],
         is_account_admin: user_being_changed_is_account_admin?,
       },
       status: :ok,
@@ -81,14 +82,20 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     end
   end
 
-  def fetch_original_user
-    original_user = search_for_users_on_canvas(params[:id]).first
+  def fetch_canvas_user
+    canvas_user = canvas_api.proxy(
+      "SHOW_USER_DETAILS",
+      { id: params[:id] },
+    )
 
-    @original_user = HashWithIndifferentAccess.new(original_user)
+    @canvas_user = HashWithIndifferentAccess.new(canvas_user)
   end
 
   def validate_user_being_changed_is_in_account
-    user_is_in_account = @original_user.present?
+    # We're searching with the login ID because it's more likely to be unique than the numeric ID.
+    # Also, the numeric ID may not be 3 characters long as required by the API.
+    matching_users = search_for_users_in_account(@canvas_user[:login_id])
+    user_is_in_account = matching_users.any? { |user| user["id"] == params[:id].to_i }
 
     unless user_is_in_account
       user_not_authorized(
@@ -107,7 +114,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     end
   end
 
-  def search_for_users_on_canvas(search_term, page = nil)
+  def search_for_users_in_account(search_term, page = nil)
     # We're manually constructing the URL here and using `api_get_request` instead of
     # `canvas_api.proxy("LIST_USERS_IN_ACCOUNT", params)` because `proxy("LIST_USERS_IN_ACCOUNT")`
     # doesn't support the `include` param since it's undocumented.
@@ -148,12 +155,12 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     )
 
     matching_login = list_user_logins_response.detect do |login|
-      login["unique_id"] == @original_user[:login_id]
+      login["unique_id"] == @canvas_user[:login_id]
     end
 
     unless matching_login
       raise LMS::Canvas::CanvasException.new(
-        "Failed to find matching login for user with login ID: #{@original_user[:login_id]}",
+        "Failed to find matching login for user with login ID: #{@canvas_user[:login_id]}",
       )
     end
 
@@ -172,7 +179,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
     CanvasUserChange.create_by_diffing_attrs!(
       admin_making_changes_lms_id: current_user.lms_user_id,
       user_being_changed_lms_id: params[:id],
-      original_attrs: @original_user,
+      original_attrs: @canvas_user,
       new_attrs: params[:user].permit([:name, :login_id, :sis_user_id, :email]).to_h,
       failed_attrs: failed_attrs,
     )
@@ -198,12 +205,12 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
   end
 
   def name_or_email_changed?
-    CanvasUserChange.attr_changed?(@original_user, params[:user], :name) ||
-      CanvasUserChange.attr_changed?(@original_user, params[:user], :email)
+    CanvasUserChange.attr_changed?(@canvas_user, params[:user], :name) ||
+      CanvasUserChange.attr_changed?(@canvas_user, params[:user], :email)
   end
 
   def login_id_or_sis_id_changed?
-    CanvasUserChange.attr_changed?(@original_user, params[:user], :login_id) ||
-      CanvasUserChange.attr_changed?(@original_user, params[:user], :sis_user_id)
+    CanvasUserChange.attr_changed?(@canvas_user, params[:user], :login_id) ||
+      CanvasUserChange.attr_changed?(@canvas_user, params[:user], :sis_user_id)
   end
 end

--- a/app/controllers/api/canvas_account_users_controller.rb
+++ b/app/controllers/api/canvas_account_users_controller.rb
@@ -88,7 +88,7 @@ class Api::CanvasAccountUsersController < Api::ApiApplicationController
 
     unless user_is_in_account
       user_not_authorized(
-        "You are only authorized to modify users from the account or sub-accounts you administer.",
+        "You are only authorized to view or modify users from the current account.",
       )
     end
 

--- a/spec/controllers/api/canvas_account_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_account_users_controller_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
         response = put(:update, format: :json, params: params)
 
         expect(JSON.parse(response.body)["message"]).
-          to match(/modify users from the account/i)
+          to match(/view or modify users from the current account/i)
       end
     end
 

--- a/spec/controllers/api/canvas_account_users_controller_spec.rb
+++ b/spec/controllers/api/canvas_account_users_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
     end
     let(:user) do
       {
-        "id" => "412",
+        "id" => 412,
         "name" => "John Adams",
         "login_id" => "adamsforindependence@greatbritain.com",
         "sis_user_id" => "old_john_123",
@@ -96,8 +96,12 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
     end
 
     before do
+      allow_any_instance_of(LMS::Canvas).to receive(:proxy).
+        with("SHOW_USER_DETAILS", id: params[:id]).
+        and_return(user.clone)
+
       allow_any_instance_of(LMS::Canvas).to receive(:api_get_request).
-        with(a_string_matching(/users\?.*search_term=#{params[:id]}/i)).
+        with(a_string_matching(/users\?.*#{{ search_term: user["login_id"] }.to_query}/i)).
         and_return([user.clone])
 
       allow_any_instance_of(LMS::Canvas).to receive(:proxy).
@@ -152,7 +156,7 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
     end
     let(:original_user) do
       {
-        "id" => "412",
+        "id" => 412,
         "name" => "Old School John Adams",
         "login_id" => "adamsforindependence@greatbritain.com",
         "sis_user_id" => "old_john_123",
@@ -162,8 +166,12 @@ RSpec.describe Api::CanvasAccountUsersController, type: :controller do
     let(:numeric_login_id) { 4989 }
 
     before do
+      allow_any_instance_of(LMS::Canvas).to receive(:proxy).
+        with("SHOW_USER_DETAILS", id: params[:id]).
+        and_return(original_user)
+
       allow_any_instance_of(LMS::Canvas).to receive(:api_get_request).
-        with(a_string_matching(/users\?.*search_term=#{params[:id]}/i)).
+        with(a_string_matching(/users\?.*#{{ search_term: original_user["login_id"] }.to_query}/i)).
         and_return([original_user])
 
       allow_any_instance_of(LMS::Canvas).to receive(:proxy).


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#172592283](https://www.pivotaltracker.com/story/show/172592283)

The Canvas API docs for the [List users in account](https://canvas.instructure.com/doc/api/users.html#method.users.api_index) endpoint for the `search_term` parameter state, "Note that the API will prefer matching on canonical user ID if the ID has a numeric form. It will only search against other fields if non-numeric in form, or if the numeric value doesn't yield any matches." But that doesn't appear to be the case in my testing. I added the ID of one user to the name of another user and it pulled up both users when I searched using that ID.

There are a couple of places in the `CanvasAccountUsersController` where we search for users by ID when we want a specific user. Searching for users with their ID will cause issues if there's ever a user who has the ID of another user in their SIS ID or something like that.

Searching for users by ID also doesn't work if the user's ID is less than 3 characters. The API docs say the `search_term` must be at least 3 characters. I assumed this wouldn't apply to IDs, but I was incorrect. Searching for a user whose ID is 99 or less will give you a `400 Bad Request`.

Another problem with the current implementation is that, in the case where a user's ID exists in another user's SIS ID, email or some other attribute, we might erroneously conclude that a user is in the account and can thus be updated when they really aren't.

This branch removes the instances where we search for a user with their ID and instead makes use of the `/users/:id` Canvas API endpoint. Also, it searches using the user's login ID when we need to search for a specific user.

## Tradeoffs & Alternatives
This branch adds an additional call to the Canvas API to fetch the Canvas user in the `#show` and `#update` actions. We do this so we have their login ID when verifying if the user is in the current account. This additional call could be avoided if we required the client of our API to include the Canvas user's original login ID with requests to `#show` and `#update`. I concluded breaking from REST conventions and complicating the interface of our back-end API like this wasn't worth saving a call to Canvas. Performance will be negatively impacted, but not in a significant way. I'd rather prioritize maintaining a higher quality API interface than performance as long as the performance costs are reasonable. If anyone disagrees with this line of reasoning, please let me know.

One other thing to be aware of is that searching for a specific user with their login ID still has the problem of maybe not having 3 characters. If the student's login ID is 1 or 2 characters, a request to show or update that user will fail. This possibility seems very unlikely to me though, so I'm not sure it's worth worrying about.