### PR TITLE
safari search fix

### DIFF
--- a/client/apps/user_tool/styles/partials/_inputs.scss
+++ b/client/apps/user_tool/styles/partials/_inputs.scss
@@ -14,9 +14,13 @@
     color: $gray3;
     padding: 0 1rem;
     margin-right: 0.4rem;
+    -webkit-appearance: none; //fix safari
 
     &:focus{
       outline: thin dotted $blue;
+    }
+    &::-webkit-search-decoration{
+      -webkit-appearance: none; //fix safari
     }
   }
 


### PR DESCRIPTION
Safari treats type="search" differently for some reason so these few lines of code fix that.