### PR TITLE
Adjust error handling for routing error

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,10 @@
 ;;; -*- fill-column: 80; -*-
 
+Changes for 2.0.3
+  * Adjust error handling for routing error
+    * Don't send an email for a routing error. Just display the 404 page.
+
+
 Changes for 2.0.2
   * Fix course completion paging issue
   * Update gems to match deploy

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -112,7 +112,9 @@ class ApplicationController < ActionController::Base
     @backtrace = e.backtrace
     @status = ActionDispatch::ExceptionWrapper.new(request.env, e).status_code
 
-    ErrorMailer.error_email(current_user, error_info.to_json).deliver_later
+    if send_error_email_for(e.class)
+      ErrorMailer.error_email(current_user, error_info.to_json).deliver_later
+    end
 
     respond_to do |format|
       format.html { render_html_error }
@@ -171,6 +173,16 @@ class ApplicationController < ActionController::Base
       exception: "#{@exception_name} : #{@exception}",
       backtrace: @backtrace,
     }
+  end
+
+  def ignore_exception_level_filters
+    [
+      ActionController::RoutingError,
+    ]
+  end
+
+  def send_error_email_for(error_class)
+    ignore_exception_level_filters.exclude?(error_class)
   end
 
   # **********************************************


### PR DESCRIPTION
Don't send an email for a routing error. Just display the 404 page.