### PR TITLE
Fix Search Bug in User Tool

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 ;;; -*- fill-column: 80; -*-
 
+Changes for 2.0.5
+  * Fix bug in the user tool where search terms with a "+" character were not
+    returning the expected results.
+
 Changes for 2.0.4
   * Don't send error emails for invalid auth tokens.
 

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -9,15 +9,19 @@ const requests = ['SEARCH_FOR_ACCOUNT_USERS', 'GET_ACCOUNT_USER', 'UPDATE_ACCOUN
 
 export const Constants = wrapper(actions, requests);
 
-export const searchForAccountUsers = (searchTerm, page) => ({
-  type: Constants.SEARCH_FOR_ACCOUNT_USERS,
-  method: Network.GET,
-  url: 'api/canvas_account_users',
-  params: {
-    search_term: searchTerm,
-    page,
-  },
-});
+export const searchForAccountUsers = (searchTerm, page) => {
+  const encodedSearchTerm = encodeURIComponent(searchTerm);
+
+  return {
+    type: Constants.SEARCH_FOR_ACCOUNT_USERS,
+    method: Network.GET,
+    url: 'api/canvas_account_users',
+    params: {
+      search_term: encodedSearchTerm,
+      page,
+    },
+  };
+};
 
 export const getAccountUser = userId => ({
   type: Constants.GET_ACCOUNT_USER,

--- a/client/apps/user_tool/actions/application.spec.js
+++ b/client/apps/user_tool/actions/application.spec.js
@@ -3,7 +3,7 @@ import { searchForAccountUsers, getAccountUser, updateAccountUser } from './appl
 describe('application actions', () => {
   describe('searchForAccountUsers', () => {
     it('generates the correct action', () => {
-      const searchTerm = 'student name';
+      const searchTerm = 'student_name';
       const page = '2';
       const expectedAction = {
         type: 'SEARCH_FOR_ACCOUNT_USERS',
@@ -33,6 +33,23 @@ describe('application actions', () => {
         };
 
         expect(searchForAccountUsers(searchTerm, page)).toEqual(expectedAction);
+      });
+    });
+
+    describe('when the search term includes a plus sign', () => {
+      it('escapes the plus sign in the search term', () => {
+        const searchTerm = 'john+smith';
+        const expectedAction = {
+          type: 'SEARCH_FOR_ACCOUNT_USERS',
+          method: 'get',
+          url: 'api/canvas_account_users',
+          params: {
+            search_term: 'john%2Bsmith',
+            page: undefined,
+          },
+        };
+
+        expect(searchForAccountUsers(searchTerm)).toEqual(expectedAction);
       });
     });
   });


### PR DESCRIPTION
## Goal
Pivotal Tracker: [#171524339](https://www.pivotaltracker.com/story/show/171524339)

We observed a bug where search terms with a "+" character in them weren't returning any results from the Canvas API even though there were users that matched the search term.

The problem was that the plus sign was being sent to our back-end as a space character instead of a literal plus sign. This search term with a space instead of a plus was then sent to the Canvas API and there were no matching results.

By URI encoding the search term before sending it to our back-end, we get the results we expect.

I also tested searching with a number of other special characters (~, !, /, #, ?, etc.) and they all worked fine.