### PR TITLE
Increase Client-side Network Timeout

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,10 @@
 ;;; -*- fill-column: 80; -*-
 
+Changes for 2.0.5
+  * Increase client-side timeout from 20 seconds to 60 seconds to accommodate
+    slow response times.
+
+
 Changes for 2.0.4
   * Don't send error emails for invalid auth tokens.
 

--- a/client/apps/user_tool/actions/application.js
+++ b/client/apps/user_tool/actions/application.js
@@ -1,6 +1,9 @@
 import wrapper from 'atomic-fuel/libs/constants/wrapper';
 import Network from 'atomic-fuel/libs/constants/network';
 
+// Increasing timeout to accomodate slow environments. Default is 20_000.
+Network.TIMEOUT = 60_000;
+
 // Local actions
 const actions = [];
 


### PR DESCRIPTION
We're having problems in the AU staging environment where requests are taking longer than 20 seconds and are timing out so the user can't perform certain actions. Increasing the timeout to 60 seconds won't improve the slow performance obviously, but it will at least prevent requests from timing out and will allow the user to use the application normally (albeit slowly).