### PR TITLE
Ensure Rustici engine has student registration

### DIFF
--- a/app/helpers/scorm_course_helper.rb
+++ b/app/helpers/scorm_course_helper.rb
@@ -19,6 +19,9 @@ module ScormCourseHelper
     launch = @scorm_connect.launch_course(
       registration,
       params[:launch_presentation_return_url],
+      scorm_courses_postback_url,
+      params,
+      current_application_instance,
     )
 
     @scorm_connect.sync_registration(params)

--- a/app/services/scorm_cloud_service.rb
+++ b/app/services/scorm_cloud_service.rb
@@ -11,7 +11,7 @@ class ScormCloudService
   end
 
   ### Scorm Cloud api wrapper methods
-  def launch_course(registration, redirect_url)
+  def launch_course(registration, redirect_url, _postback_url, _result_params = {}, _lti_credentials = {})
     scorm_cloud_request do
       @scorm_cloud.registration.launch(registration.scorm_registration_id, redirect_url)
     end

--- a/app/services/scorm_common_service.rb
+++ b/app/services/scorm_common_service.rb
@@ -64,20 +64,24 @@ module ScormCommonService
     )
     if registration.nil?
       registration = create_local_registration(result_params, lti_credentials)
-      user = {
-        first_name: result_params[:lis_person_name_given],
-        last_name: result_params[:lis_person_name_family],
-        lms_user_id: result_params[:custom_canvas_user_id],
-      }
-      setup_scorm_registration(
-        registration,
-        user,
-        postback_url,
-        lti_credentials.lti_key,
-        result_params[:course_id],
-      )
+      create_scorm_registration(postback_url, result_params, registration, lti_credentials)
     end
     registration
+  end
+
+  def create_scorm_registration(postback_url, result_params, registration, lti_credentials)
+    user = {
+      first_name: result_params[:lis_person_name_given],
+      last_name: result_params[:lis_person_name_family],
+      lms_user_id: result_params[:custom_canvas_user_id],
+    }
+    setup_scorm_registration(
+      registration,
+      user,
+      postback_url,
+      lti_credentials.lti_key,
+      result_params[:course_id],
+    )
   end
 
   ### Sync Utilities

--- a/spec/services/scorm_engine_service_spec.rb
+++ b/spec/services/scorm_engine_service_spec.rb
@@ -60,7 +60,7 @@ describe "launch_course" do
     launch_route = "/launchLink"
     stub_request(:any, launch_url).to_return(body: "{ \"launchLink\": \"#{launch_route}\" }")
 
-    response = @subject.launch_course(@reg, "")
+    response = @subject.launch_course(@reg, "", Rails.application.routes.url_helpers.scorm_courses_postback_url)
     expect(response[:response]).to eq(Rails.application.secrets.scorm_url + launch_route)
     expect(response[:status]).to eq(200)
   end


### PR DESCRIPTION
If something glitches during the initial registration with Rustici, that launch is forever orphaned. This fixes it so if the registration is not present while launching the course, it will get created.