### PR TITLE
Remove Atomic Jolt logo from error pages

### DIFF
--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -6,7 +6,6 @@
     <%= render 'layouts/head' %>
   </head>
   <body>
-    <%= render 'layouts/navigation' %>
     <div>
       <%= render 'layouts/messages' %>
       <%= yield %>


### PR DESCRIPTION
No need to have our logo on the error page.