### PR TITLE
Stop leaking gems in backtrace for errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,7 +117,7 @@ class ApplicationController < ActionController::Base
   def error(e)
     @exception = e.message
     @exception_name = e.class.name
-    @backtrace = e.backtrace
+    @backtrace = e.backtrace.select { |trace| trace.starts_with? Rails.root.to_s }
     @status = ActionDispatch::ExceptionWrapper.new(request.env, e).status_code
 
     if send_error_email_for(e.class)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,7 +120,7 @@ class ApplicationController < ActionController::Base
     @backtrace = e.
       backtrace.
       select { |trace| trace.starts_with? Rails.root.to_s }.
-      map { |trace| trace.gsub(Rails.root.to_s, "") }
+      map { |trace| trace.gsub("#{Rails.root}/", "") }
     @status = ActionDispatch::ExceptionWrapper.new(request.env, e).status_code
 
     if send_error_email_for(e.class)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,7 +117,10 @@ class ApplicationController < ActionController::Base
   def error(e)
     @exception = e.message
     @exception_name = e.class.name
-    @backtrace = e.backtrace.select { |trace| trace.starts_with? Rails.root.to_s }
+    @backtrace = e.
+      backtrace.
+      select { |trace| trace.starts_with? Rails.root.to_s }.
+      map { |trace| trace.gsub(Rails.root.to_s, "") }
     @status = ActionDispatch::ExceptionWrapper.new(request.env, e).status_code
 
     if send_error_email_for(e.class)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,7 +120,7 @@ class ApplicationController < ActionController::Base
     @backtrace = e.
       backtrace.
       select { |trace| trace.starts_with? Rails.root.to_s }.
-      map { |trace| trace.gsub("#{Rails.root}/", "") }
+      map { |trace| trace.gsub("#{Rails.root}/", "") } # rubocop:disable Rails/FilePath
     @status = ActionDispatch::ExceptionWrapper.new(request.env, e).status_code
 
     if send_error_email_for(e.class)


### PR DESCRIPTION
This leaks information about our server that could be a potential security risk. For example it leaks specific information about library versions we use. If a bad actor knows this information, they could use that to their advantage to attack the service.

For example, this error:

```
404 Not Found
/var/adhesion-gems/ruby/2.5.0/gems/rest-client-2.1.0/lib/restclient/abstract_response.rb:249:in `exception_with_response'
/var/adhesion-gems/ruby/2.5.0/gems/rest-client-2.1.0/lib/restclient/abstract_response.rb:129:in `return!'
/var/adhesion-gems/ruby/2.5.0/gems/rest-client-2.1.0/lib/restclient/request.rb:836:in `process_result'
/var/adhesion-gems/ruby/2.5.0/gems/rest-client-2.1.0/lib/restclient/request.rb:743:in `block in transmit'
/usr/lib/ruby/2.5.0/net/http.rb:910:in `start'
/var/adhesion-gems/ruby/2.5.0/gems/rest-client-2.1.0/lib/restclient/request.rb:727:in `transmit'
/var/adhesion-gems/ruby/2.5.0/gems/rest-client-2.1.0/lib/restclient/request.rb:163:in `execute'
/var/adhesion-gems/ruby/2.5.0/gems/rest-client-2.1.0/lib/restclient/request.rb:63:in `execute'
/var/adhesion/app/services/scorm_engine_service.rb:240:in `send_get_request'
/var/adhesion/app/services/scorm_engine_service.rb:235:in `get_launch_link'
/var/adhesion/app/services/scorm_engine_service.rb:13:in `launch_course'
/var/adhesion/app/helpers/scorm_course_helper.rb:19:in `launch_scorm_course'
/var/adhesion/app/controllers/lti_launches_controller.rb:43:in `show'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/abstract_controller/base.rb:194:in `process_action'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_controller/metal/rendering.rb:30:in `process_action'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:132:in `run_callbacks'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/abstract_controller/callbacks.rb:41:in `process_action'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_controller/metal/rescue.rb:22:in `process_action'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `block in instrument'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `instrument'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
/var/adhesion-gems/ruby/2.5.0/gems/activerecord-5.2.3/lib/active_record/railties/controller_runtime.rb:24:in `process_action'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/abstract_controller/base.rb:134:in `process'
/var/adhesion-gems/ruby/2.5.0/gems/actionview-5.2.3/lib/action_view/rendering.rb:32:in `process'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_controller/metal.rb:191:in `dispatch'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_controller/metal.rb:252:in `dispatch'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:34:in `serve'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:52:in `block in serve'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:35:in `each'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:35:in `serve'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:840:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'
/var/adhesion-gems/ruby/2.5.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'
/var/adhesion/app/middleware/requests_logger.rb:7:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/warden-1.2.8/lib/warden/manager.rb:36:in `block in call'
/var/adhesion-gems/ruby/2.5.0/gems/warden-1.2.8/lib/warden/manager.rb:34:in `catch'
/var/adhesion-gems/ruby/2.5.0/gems/warden-1.2.8/lib/warden/manager.rb:34:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/apartment-2.2.1/lib/apartment/elevators/generic.rb:21:in `block in call'
/var/adhesion-gems/ruby/2.5.0/gems/apartment-2.2.1/lib/apartment/adapters/abstract_adapter.rb:85:in `switch'
/var/adhesion-gems/ruby/2.5.0/gems/apartment-2.2.1/lib/apartment/elevators/generic.rb:21:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/tempfile_reaper.rb:15:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/etag.rb:27:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/conditional_get.rb:40:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/head.rb:12:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/http/content_security_policy.rb:18:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:266:in `context'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:260:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/cookies.rb:670:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:98:in `run_callbacks'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/railties-5.2.3/lib/rails/rack/logger.rb:38:in `call_app'
/var/adhesion-gems/ruby/2.5.0/gems/railties-5.2.3/lib/rails/rack/logger.rb:26:in `block in call'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71:in `block in tagged'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:28:in `tagged'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71:in `tagged'
/var/adhesion-gems/ruby/2.5.0/gems/railties-5.2.3/lib/rails/rack/logger.rb:26:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/request_id.rb:27:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/executor.rb:14:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/actionpack-5.2.3/lib/action_dispatch/middleware/ssl.rb:74:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/rack-cors-1.1.1/lib/rack/cors.rb:100:in `call'
/var/adhesion/app/lib/middleware/oauth_state_middleware.rb:96:in `call'
/var/adhesion-gems/ruby/2.5.0/gems/railties-5.2.3/lib/rails/engine.rb:524:in `call'
/usr/lib/ruby/vendor_ruby/phusion_passenger/rack/thread_handler_extension.rb:97:in `process_request'
/usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:160:in `accept_and_process_next_request'
/usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:113:in `main_loop'
/usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler.rb:416:in `block (3 levels) in start_threads'
/usr/lib/ruby/vendor_ruby/phusion_passenger/utils.rb:113:in `block in create_thread_and_abort_on_exception'
```

Will now show as this:

```
404 Not Found
app/services/scorm_engine_service.rb:240:in `send_get_request'
app/services/scorm_engine_service.rb:235:in `get_launch_link'
app/services/scorm_engine_service.rb:13:in `launch_course'
app/helpers/scorm_course_helper.rb:19:in `launch_scorm_course'
app/controllers/lti_launches_controller.rb:43:in `show'
app/middleware/requests_logger.rb:7:in `call'
app/lib/middleware/oauth_state_middleware.rb:96:in `call'
```