### PR TITLE
Fix fullscreen mode to work within speedgrader

### DIFF
--- a/client/apps/docviewer/components/main/annotation_controls.jsx
+++ b/client/apps/docviewer/components/main/annotation_controls.jsx
@@ -19,10 +19,16 @@ export default class AnnotationControls extends React.Component {
     };
   }
 
-  componentDidUpdate() {
-    const { tool } = this.state;
+  componentDidUpdate(prevProps) {
     const { UI } = this.props;
-    if (UI && tool == null) {
+    if (prevProps.UI !== UI && UI !== null) {
+      this.initializeTools(UI);
+    }
+  }
+
+  initializeTools(UI) {
+    const { tool } = this.state;
+    if (tool === null) {
       this.setState({ tool: 'selection' }, () => {
         this.disableTools();
         UI.enableEdit();

--- a/client/apps/docviewer/components/main/annotation_controls.jsx
+++ b/client/apps/docviewer/components/main/annotation_controls.jsx
@@ -19,6 +19,17 @@ export default class AnnotationControls extends React.Component {
     };
   }
 
+  componentDidUpdate() {
+    const { tool } = this.state;
+    const { UI } = this.props;
+    if (UI && tool == null) {
+      this.setState({ tool: 'selection' }, () => {
+        this.disableTools();
+        UI.enableEdit();
+      });
+    }
+  }
+
   disableTools() {
     const { UI, toggleSecondary } = this.props;
     UI.disableEdit();

--- a/client/apps/docviewer/components/main/document_controls.jsx
+++ b/client/apps/docviewer/components/main/document_controls.jsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { broadcastRawMessage } from 'atomic-fuel/libs/communications/communicator';
 import ToolButton from '../common/tool_button';
 
 export class DocumentControls extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      fullscreen: false
+    };
+  }
+
   rotate = () => {
     const { RENDER_OPTIONS, handleRerender } = this.props;
     RENDER_OPTIONS.rotate -= 90;
@@ -22,17 +30,23 @@ export class DocumentControls extends React.Component {
     handleRerender();
   }
 
-  fullScreen = () => {
-    const { handleFullScreen } = this.props;
-    handleFullScreen();
+  enableFullscreen = () => {
+    this.setState({ fullscreen: true });
+    broadcastRawMessage('{ "subject": "app.enableFullscreen" }');
+  }
+
+  closeFullscreen = () => {
+    this.setState({ fullscreen: false });
+    broadcastRawMessage('{ "subject": "app.disableFullscreen" }');
   }
 
   render() {
     const { annotations } = this.props;
+    const { fullscreen } = this.state;
     return (
       <nav className="document-controls">
         <ToolButton
-          disabled={annotations.length >= 0}
+          disabled={annotations && annotations.length > 0}
           icon="rotate_90_degrees_ccw"
           onClick={this.rotate}
         />
@@ -51,10 +65,16 @@ export class DocumentControls extends React.Component {
         <svg viewBox="0 0 2 26" className="primary-controls_divider">
           <line stroke="currentColor" strokeDasharray="2, 1" strokeWidth="1" x1="1" y1="0" x2="1" y2="26" />
         </svg>
-        <ToolButton
-          icon="open_in_full"
-          onClick={this.fullScreen}
-        />
+        {!fullscreen
+          && <ToolButton
+            icon="open_in_full"
+            onClick={this.enableFullscreen}
+          />}
+        {fullscreen
+          && <ToolButton
+            icon="close_fullscreen"
+            onClick={this.closeFullscreen}
+          />}
       </nav>
     );
   }
@@ -62,10 +82,9 @@ export class DocumentControls extends React.Component {
 DocumentControls.propTypes = {
   RENDER_OPTIONS: PropTypes.object,
   handleRerender: PropTypes.func,
-  handleFullScreen: PropTypes.func
 };
 
-const select = state => ({
+const select = (state) => ({
   annotations: state.annotations.annotations
 });
 

--- a/client/apps/docviewer/components/main/document_controls.jsx
+++ b/client/apps/docviewer/components/main/document_controls.jsx
@@ -84,7 +84,7 @@ DocumentControls.propTypes = {
   handleRerender: PropTypes.func,
 };
 
-const select = (state) => ({
+const select = state => ({
   annotations: state.annotations.annotations
 });
 

--- a/client/apps/docviewer/components/main/docviewer.jsx
+++ b/client/apps/docviewer/components/main/docviewer.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PDFJSAnnotate from 'pdf-annotate.js';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import FullScreen from 'react-full-screen';
 import * as pdfjsLib from 'pdfjs-dist/webpack';
 import * as pdfjsViewer from 'pdfjs-dist/web/pdf_viewer';
 import Communicator, { broadcastRawMessage } from 'atomic-fuel/libs/communications/communicator';
@@ -134,19 +133,14 @@ export class Docviewer extends React.Component {
     const { isFull, renderOptions } = this.state;
     return (
       <React.Fragment>
-        <FullScreen
-          enabled={isFull}
-          onChange={fullscreen => this.setState({ isFull: fullscreen })}
-        >
-          <PrimaryToolbar
-            UI={this.UI}
-            RENDER_OPTIONS={renderOptions}
-            handleRerender={this.handleRerender}
-            handleFullScreen={this.handleFullScreen}
-          />
-          <div className="toolbar" />
-          <div id="viewer" className="pdfViewer" />
-        </FullScreen>
+        <PrimaryToolbar
+          UI={this.UI}
+          RENDER_OPTIONS={renderOptions}
+          handleRerender={this.handleRerender}
+          handleFullScreen={this.handleFullScreen}
+        />
+        <div className="toolbar" />
+        <div id="viewer" className="pdfViewer" />
       </React.Fragment>
     );
   }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "react-dnd-html5-backend": "^2.3.0",
     "react-dom": "^16.12.0",
     "react-dropzone-s3-uploader": "^1.0.0-rc.3",
-    "react-full-screen": "0.2.4",
     "react-modal": "^3.10.1",
     "react-modal1": "npm:react-modal@1.9.7",
     "react-paginate": "^5.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,23 +1340,10 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prop-types@*":
-  version "15.7.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
-
-"@types/react@*":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
-  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -5195,11 +5182,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-
-fscreen@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fscreen/-/fscreen-1.1.0.tgz#80f432f24dc915ba0be0f5f6a7d60ca12ecbab5c"
-  integrity sha512-nSRkgHknnCRy7ZBWIu9S4IWe1m/VBROczUEU4RzXK3QvDtc89m79m4e5mbyFSugewgB8ajQKsDzeqaQ8sZ+7hA==
 
 fsevents@^1.2.7:
   version "1.2.13"
@@ -9435,14 +9417,6 @@ react-dropzone@^4.0.0:
   dependencies:
     attr-accept "^1.1.3"
     prop-types "^15.5.7"
-
-react-full-screen@0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/react-full-screen/-/react-full-screen-0.2.4.tgz#e5bda9535abb6523b65e0e46526c8f21be65ef7e"
-  integrity sha512-K6V87g/uopQnnebg6/jM7VL3FcurgCIQU4nTkzknbjGOT9XOOxr3XVwRweI8QPn1TFRZH7j5OpHanUdk5uYlBQ==
-  dependencies:
-    "@types/react" "*"
-    fscreen "^1.0.1"
 
 react-input-autosize@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
Pivotal Tracker:
- [#176577175 - Full screen does not work within speed grader](https://www.pivotaltracker.com/story/show/176577175)

Fixes to enable fullscreen mode in canvas's speedgrader. Since the app is placed within an iframe, react-fullscreen-screen would try to access the wrong document. I had to broadcast a message to the global javascript which handles the rendering in full screen.