### PR TITLE
Fix scorm redirect on exit for previews

### DIFF
--- a/app/services/scorm_engine_service.rb
+++ b/app/services/scorm_engine_service.rb
@@ -173,7 +173,12 @@ class ScormEngineService
   end
 
   def preview_course(course_id, redirect_url)
-    body = { redirectOnExitUrl: redirect_url } if redirect_url
+    redirect_on_exit_url = if redirect_url.present?
+      redirect_url
+    else
+      "noop_message=Preview is over. Please close this window."
+    end
+    body = { redirectOnExitUrl: redirect_on_exit_url }
     url = "#{@scorm_tenant_url}/courses/#{course_id}/preview"
     response = send_get_request(url, body)
     launch_link = JSON.parse(response.body)["launchLink"]


### PR DESCRIPTION
Even previews must have a redirect url. This can be a noop or a noop_message.

See https://rustici-docs.s3.amazonaws.com/engine/2017.1.x/GettingStarted/Launching.html#preview-launches